### PR TITLE
[0/n] Improve etcd compatibility for newer Kubernetes and add benchmarks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,23 +1,61 @@
 name: Tests
 
-on: [pull_request]
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+      - support-v1.35
+  workflow_dispatch:
 
 jobs:
-  test:
+  unit:
+    name: Unit & Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v3
+      - name: Check out code
+        uses: actions/checkout@v4
 
       - name: Set up Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.18
+          go-version: "1.25.x"
 
       - name: Build
         run: go build -v ./...
 
-      - name: Test
+      - name: Unit tests with coverage
         run: make test-coverage
 
-      - name: Codecov
-        uses: codecov/codecov-action@v3.1.0
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          fail_ci_if_error: false
+
+  e2e-kind:
+    name: Kind E2E
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    needs: unit
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.x"
+
+      - name: Set up kubectl
+        uses: azure/setup-kubectl@v4
+
+      - name: Set up kind
+        uses: engineerd/setup-kind@v0.6.2
+        with:
+          version: v0.24.0
+
+      - name: Run kind e2e
+        env:
+          K8S_IMAGE: kindest/node:v1.35.0
+        run: make e2e-kind

--- a/build/build-badger.sh
+++ b/build/build-badger.sh
@@ -17,6 +17,8 @@ BIN_NAME="kube-brain"
 BIN_DIR="./bin"
 WORK_DIR="$(cd "$(dirname "${BASH_SOURCE}")/.." && pwd -P)"
 
+set -euo pipefail
+
 echo ${WORK_DIR}
 cd ${WORK_DIR} || exit
 mkdir -p $BIN_DIR

--- a/build/build-base.sh
+++ b/build/build-base.sh
@@ -13,8 +13,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if [[ "${DEBUG:-0}" == "1" ]]; then
+  set -x
+fi
+
 export pkg="github.com/kubewharf/kubebrain/cmd/version"
-export version=$(git describe --abbrev=0 --tags || git rev-parse --abbrev-ref HEAD) # tag or branch
+
+# Prefer the latest tag. Fall back to branch name without noisy git errors.
+if version_from_tag=$(git describe --abbrev=0 --tags 2>/dev/null); then
+  export version="$version_from_tag"
+else
+  export version=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "unknown")
+fi
 export sha=$(git rev-parse --short HEAD)                                            # commit id
 export go_version=$(go env GOVERSION)
 export go_os=$(go env GOOS)

--- a/build/build-tikv.sh
+++ b/build/build-tikv.sh
@@ -17,6 +17,8 @@ BIN_NAME="kube-brain"
 BIN_DIR="./bin"
 WORK_DIR="$(cd "$(dirname "${BASH_SOURCE}")/.." && pwd -P)"
 
+set -euo pipefail
+
 echo ${WORK_DIR}
 cd ${WORK_DIR} || exit
 mkdir -p $BIN_DIR

--- a/docs/benchmark_kind.md
+++ b/docs/benchmark_kind.md
@@ -1,0 +1,48 @@
+# Kind Benchmark Comparison
+
+This benchmark compares two storage backends under the same kind + kube-apiserver setup:
+
+- `etcd`: default kind control-plane etcd
+- `kubebrain`: kube-apiserver redirected to KubeBrain (`--compatible-with-etcd=true`)
+
+## Quick Run
+
+```bash
+make bench-kind-compare
+```
+
+Result is written to:
+
+```text
+test/benchmark/kind/results/kind-compare-<timestamp>.tsv
+```
+
+The script also prints a markdown table with:
+
+- `ops/s`: successful operation throughput
+- `avg_ms`, `p50_ms`, `p90_ms`, `p99_ms`: latency of one CRUD sequence (`create + patch + delete` on ConfigMap)
+
+## Useful Parameters
+
+```bash
+BENCH_OPS=400 BENCH_CONCURRENCY=16 BENCH_WARMUP=40 make bench-kind-compare
+```
+
+```bash
+K8S_IMAGE=m.daocloud.io/docker.io/kindest/node:v1.35.0 make bench-kind-compare
+```
+
+```bash
+KEEP_CLUSTERS=true make bench-kind-compare
+```
+
+```bash
+SKIP_BUILD=true make bench-kind-compare
+```
+
+## Notes
+
+- Run on an idle machine; avoid other heavy workloads.
+- Keep all benchmark parameters identical when comparing.
+- Do multiple runs and compare median results, not a single run.
+- If you set `KUBEBRAIN_KEY_PREFIX`, do not end it with `/`.

--- a/docs/benchmark_kwok.md
+++ b/docs/benchmark_kwok.md
@@ -1,0 +1,71 @@
+# KWOK Benchmark Comparison
+
+This benchmark compares control-plane performance between:
+
+- `etcd` (baseline): standard kwok cluster
+- `kubebrain` (modified): kube-apiserver redirected to KubeBrain etcd-compatible endpoint
+
+The benchmark target is:
+
+- `100` fake nodes
+- `10000` pods (Deployment replicas)
+
+## Prerequisites
+
+- `kwokctl`
+- `kind`
+- `kubectl`
+- `docker`
+- `make`
+
+## Run
+
+```bash
+make bench-kwok-compare
+```
+
+Result file:
+
+```text
+test/benchmark/kwok/results/kwok-compare-<timestamp>.tsv
+```
+
+The script prints a markdown table containing:
+
+- `nodes_seen`: nodes observed by apiserver
+- `pods_running`: number of pods reaching `Running`
+- `time_ms`: time from workload apply to `pods_running >= pods_target` (or timeout)
+- `pods/s`: `pods_running / time_ms`
+- `status`: `ok` or `timeout`
+
+## Useful Parameters
+
+Run with default large load:
+
+```bash
+FAKE_NODES=100 PODS=10000 make bench-kwok-compare
+```
+
+Quick smoke run:
+
+```bash
+FAKE_NODES=20 PODS=400 BENCH_NAMESPACE=kwok-smoke TIMEOUT_SECONDS=600 make bench-kwok-compare
+```
+
+Keep clusters for debugging:
+
+```bash
+KEEP_CLUSTERS=true make bench-kwok-compare
+```
+
+Use pre-built KubeBrain binary:
+
+```bash
+SKIP_BUILD=true make bench-kwok-compare
+```
+
+## Notes
+
+- Keep all parameters fixed between `etcd` and `kubebrain` runs.
+- Run on an idle machine; avoid other CPU/memory-heavy workloads.
+- For stable conclusions, run multiple rounds and compare medians.

--- a/makefile
+++ b/makefile
@@ -15,3 +15,7 @@ test-coverage:
 .PHONY: e2e-kind
 e2e-kind:
 	bash ./test/e2e/kind/run.sh
+
+.PHONY: bench-kind-compare
+bench-kind-compare:
+	bash ./test/benchmark/kind/compare.sh

--- a/makefile
+++ b/makefile
@@ -1,17 +1,17 @@
 
 .PHONY: badger
 badger:
-	@bash ./build/build-badger.sh
+	bash ./build/build-badger.sh
 
 
 .PHONY: tikv
 tikv:
-	@bash ./build/build-tikv.sh
+	bash ./build/build-tikv.sh
 
 .PHONY: test-coverage
 test-coverage:
-	@go test -coverprofile=coverage.out -cover=true -coverpkg=./pkg/... ./...
+	go test -coverprofile=coverage.out -cover=true -coverpkg=./pkg/... ./...
 
 .PHONY: e2e-kind
 e2e-kind:
-	@bash ./test/e2e/kind/run.sh
+	bash ./test/e2e/kind/run.sh

--- a/makefile
+++ b/makefile
@@ -11,3 +11,7 @@ tikv:
 .PHONY: test-coverage
 test-coverage:
 	@go test -coverprofile=coverage.out -cover=true -coverpkg=./pkg/... ./...
+
+.PHONY: e2e-kind
+e2e-kind:
+	@bash ./test/e2e/kind/run.sh

--- a/makefile
+++ b/makefile
@@ -19,3 +19,7 @@ e2e-kind:
 .PHONY: bench-kind-compare
 bench-kind-compare:
 	bash ./test/benchmark/kind/compare.sh
+
+.PHONY: bench-kwok-compare
+bench-kwok-compare:
+	bash ./test/benchmark/kwok/compare.sh

--- a/pkg/backend/backend_test.go
+++ b/pkg/backend/backend_test.go
@@ -1302,7 +1302,7 @@ func TestUncertainRewrite(t *testing.T) {
 	{
 		// 3
 		t.Log("write the key and expected no error")
-		rev, err := b.create(s.ctx, []byte(testKey), []byte(testVal))
+		rev, err := b.create(s.ctx, []byte(testKey), []byte(testVal), 0)
 		s.ast.Equal(initRev+3, rev)
 		s.ast.NoError(err)
 

--- a/pkg/backend/lease_compat_test.go
+++ b/pkg/backend/lease_compat_test.go
@@ -1,0 +1,71 @@
+// Copyright 2022 ByteDance and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package backend
+
+import (
+	"context"
+	"path"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	proto "github.com/kubewharf/kubebrain-client/api/v2rpc"
+)
+
+func TestCreateRequestLeaseIsApplied(t *testing.T) {
+	suite, closer := newTestSuites(t, memKvStorage)
+	defer closer()
+
+	const ttlSeconds = int64(1)
+	key := path.Join(prefix, "lease-compat", "create")
+	_, err := suite.backend.Create(context.Background(), &proto.CreateRequest{
+		Key:   []byte(key),
+		Value: []byte("value"),
+		Lease: ttlSeconds,
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		resp, getErr := suite.backend.Get(context.Background(), &proto.GetRequest{
+			Key: []byte(key),
+		})
+		return getErr == nil && resp.Kv == nil
+	}, 3*time.Second, 100*time.Millisecond)
+}
+
+func TestUpdateCreatePathLeaseIsApplied(t *testing.T) {
+	suite, closer := newTestSuites(t, memKvStorage)
+	defer closer()
+
+	const ttlSeconds = int64(1)
+	key := path.Join(prefix, "lease-compat", "update-create")
+	_, err := suite.backend.Update(context.Background(), &proto.UpdateRequest{
+		Kv: &proto.KeyValue{
+			Key:      []byte(key),
+			Value:    []byte("value"),
+			Revision: 0,
+		},
+		Lease: ttlSeconds,
+	})
+	require.NoError(t, err)
+
+	require.Eventually(t, func() bool {
+		resp, getErr := suite.backend.Get(context.Background(), &proto.GetRequest{
+			Key: []byte(key),
+		})
+		return getErr == nil && resp.Kv == nil
+	}, 3*time.Second, 100*time.Millisecond)
+}

--- a/pkg/backend/txn.go
+++ b/pkg/backend/txn.go
@@ -43,7 +43,7 @@ func (b *backend) Create(ctx context.Context, put *proto.CreateRequest) (resp *p
 			err)
 	}()
 
-	revision, err := b.create(ctx, put.Key, put.Value)
+	revision, err := b.create(ctx, put.Key, put.Value, put.Lease)
 	b.notify(ctx, put.Key, put.Value, revision, 0, err == nil, proto.Event_CREATE, err)
 	if errors.Is(err, storage.ErrCASFailed) {
 		return &proto.CreateResponse{
@@ -61,14 +61,18 @@ func (b *backend) Create(ctx context.Context, put *proto.CreateRequest) (resp *p
 	}, nil
 }
 
-func (b *backend) create(ctx context.Context, key []byte, value []byte) (revision uint64, error error) {
+func (b *backend) create(ctx context.Context, key []byte, value []byte, lease int64) (revision uint64, error error) {
 	revision, err := b.deal(0)
 	if err != nil {
 		return 0, err
 	}
 
+	ttl := lease
 	if bytes.Contains(key, events) {
-		err = b.creator.CreateWithTTL(ctx, key, value, revision, eventsTTL)
+		ttl = eventsTTL
+	}
+	if ttl != 0 {
+		err = b.creator.CreateWithTTL(ctx, key, value, revision, ttl)
 	} else {
 		err = b.creator.Create(ctx, key, value, revision)
 	}
@@ -211,7 +215,7 @@ func (b *backend) Update(ctx context.Context, r *proto.UpdateRequest) (resp *pro
 	)
 	var curRev uint64
 	if prevRev == 0 {
-		curRev, err = b.create(ctx, key, value)
+		curRev, err = b.create(ctx, key, value, lease)
 		b.notify(ctx, key, value, curRev, prevRev, err == nil, proto.Event_CREATE, err)
 	} else {
 		curRev, err = b.update(ctx, prevRev, key, value, lease)

--- a/pkg/server/etcd/backendshim.go
+++ b/pkg/server/etcd/backendshim.go
@@ -135,26 +135,47 @@ func (b *backendShim) Delete(ctx context.Context, key []byte, revision int64) (*
 	if err != nil {
 		return nil, err
 	}
-	var kvs []*mvccpb.KeyValue
-
-	if response.Kv != nil {
-		kvs = append(kvs, kvToEtcdKv(response.Kv))
-	}
-	deleteResponse := &etcdserverpb.TxnResponse{
-		Header:    txnHeader(int64(response.Header.Revision)),
+	headerRevision := int64(response.Header.Revision)
+	resp := &etcdserverpb.TxnResponse{
+		Header:    txnHeader(headerRevision),
 		Succeeded: response.Succeeded,
-		Responses: []*etcdserverpb.ResponseOp{
+	}
+	// Keep etcd txn semantics:
+	// 1) delete success branch returns DeleteRange response
+	// 2) compare-failed branch returns Range response (existing kv)
+	if response.Succeeded {
+		deleteRangeResp := &etcdserverpb.DeleteRangeResponse{
+			Header: txnHeader(headerRevision),
+		}
+		if response.Kv != nil {
+			deleteRangeResp.Deleted = 1
+			deleteRangeResp.PrevKvs = append(deleteRangeResp.PrevKvs, kvToEtcdKv(response.Kv))
+		}
+		resp.Responses = []*etcdserverpb.ResponseOp{
 			{
-				Response: &etcdserverpb.ResponseOp_ResponseRange{
-					ResponseRange: &etcdserverpb.RangeResponse{
-						Header: txnHeader(int64(response.Header.Revision)),
-						Kvs:    kvs,
-					},
+				Response: &etcdserverpb.ResponseOp_ResponseDeleteRange{
+					ResponseDeleteRange: deleteRangeResp,
 				},
+			},
+		}
+		return resp, nil
+	}
+
+	rangeResp := &etcdserverpb.RangeResponse{
+		Header: txnHeader(headerRevision),
+	}
+	if response.Kv != nil {
+		rangeResp.Kvs = append(rangeResp.Kvs, kvToEtcdKv(response.Kv))
+		rangeResp.Count = int64(len(rangeResp.Kvs))
+	}
+	resp.Responses = []*etcdserverpb.ResponseOp{
+		{
+			Response: &etcdserverpb.ResponseOp_ResponseRange{
+				ResponseRange: rangeResp,
 			},
 		},
 	}
-	return deleteResponse, nil
+	return resp, nil
 }
 
 func (b *backendShim) Update(ctx context.Context, rev int64, key []byte, value []byte, lease int64) (*etcdserverpb.TxnResponse, error) {

--- a/pkg/server/etcd/backendshim_test.go
+++ b/pkg/server/etcd/backendshim_test.go
@@ -1,0 +1,184 @@
+// Copyright 2022 ByteDance and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package etcd
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.etcd.io/etcd/api/v3/etcdserverpb"
+
+	proto "github.com/kubewharf/kubebrain-client/api/v2rpc"
+	backendpkg "github.com/kubewharf/kubebrain/pkg/backend"
+)
+
+type fakeDeleteBackend struct {
+	backendpkg.Backend
+	resp *proto.DeleteResponse
+	err  error
+}
+
+var benchmarkDeleteResp *etcdserverpb.TxnResponse
+
+func (f *fakeDeleteBackend) Delete(_ context.Context, _ *proto.DeleteRequest) (*proto.DeleteResponse, error) {
+	return f.resp, f.err
+}
+
+func TestBackendShimDeleteSuccessReturnsDeleteRange(t *testing.T) {
+	backend := &fakeDeleteBackend{
+		resp: &proto.DeleteResponse{
+			Header: &proto.ResponseHeader{
+				Revision: 123,
+			},
+			Succeeded: true,
+			Kv: &proto.KeyValue{
+				Key:      []byte("/registry/pods/default/p0"),
+				Value:    []byte("payload"),
+				Revision: 101,
+			},
+		},
+	}
+	shim := NewBackendShim(backend, nil)
+
+	resp, err := shim.Delete(context.Background(), []byte("/registry/pods/default/p0"), 101)
+	require.NoError(t, err)
+	require.True(t, resp.Succeeded)
+	require.Equal(t, int64(123), resp.Header.Revision)
+	require.Len(t, resp.Responses, 1)
+
+	deleteResp := resp.Responses[0].GetResponseDeleteRange()
+	require.NotNil(t, deleteResp)
+	require.Equal(t, int64(123), deleteResp.Header.Revision)
+	require.Equal(t, int64(1), deleteResp.Deleted)
+	require.Len(t, deleteResp.PrevKvs, 1)
+	require.Equal(t, []byte("/registry/pods/default/p0"), deleteResp.PrevKvs[0].Key)
+	require.Equal(t, []byte("payload"), deleteResp.PrevKvs[0].Value)
+	require.Equal(t, int64(101), deleteResp.PrevKvs[0].ModRevision)
+	require.Nil(t, resp.Responses[0].GetResponseRange())
+}
+
+func TestBackendShimDeleteConflictReturnsRange(t *testing.T) {
+	backend := &fakeDeleteBackend{
+		resp: &proto.DeleteResponse{
+			Header: &proto.ResponseHeader{
+				Revision: 456,
+			},
+			Succeeded: false,
+			Kv: &proto.KeyValue{
+				Key:      []byte("/registry/pods/default/p0"),
+				Value:    []byte("latest"),
+				Revision: 202,
+			},
+		},
+	}
+	shim := NewBackendShim(backend, nil)
+
+	resp, err := shim.Delete(context.Background(), []byte("/registry/pods/default/p0"), 101)
+	require.NoError(t, err)
+	require.False(t, resp.Succeeded)
+	require.Equal(t, int64(456), resp.Header.Revision)
+	require.Len(t, resp.Responses, 1)
+
+	rangeResp := resp.Responses[0].GetResponseRange()
+	require.NotNil(t, rangeResp)
+	require.Equal(t, int64(456), rangeResp.Header.Revision)
+	require.Equal(t, int64(1), rangeResp.Count)
+	require.Len(t, rangeResp.Kvs, 1)
+	require.Equal(t, []byte("/registry/pods/default/p0"), rangeResp.Kvs[0].Key)
+	require.Equal(t, []byte("latest"), rangeResp.Kvs[0].Value)
+	require.Equal(t, int64(202), rangeResp.Kvs[0].ModRevision)
+	require.Nil(t, resp.Responses[0].GetResponseDeleteRange())
+}
+
+func TestBackendShimDeleteConflictWithoutKvReturnsEmptyRange(t *testing.T) {
+	backend := &fakeDeleteBackend{
+		resp: &proto.DeleteResponse{
+			Header: &proto.ResponseHeader{
+				Revision: 789,
+			},
+			Succeeded: false,
+			Kv:        nil,
+		},
+	}
+	shim := NewBackendShim(backend, nil)
+
+	resp, err := shim.Delete(context.Background(), []byte("/registry/pods/default/p0"), 101)
+	require.NoError(t, err)
+	require.False(t, resp.Succeeded)
+	require.Len(t, resp.Responses, 1)
+
+	rangeResp := resp.Responses[0].GetResponseRange()
+	require.NotNil(t, rangeResp)
+	require.Equal(t, int64(0), rangeResp.Count)
+	require.Len(t, rangeResp.Kvs, 0)
+}
+
+func BenchmarkBackendShimDelete(b *testing.B) {
+	ctx := context.Background()
+	key := []byte("/registry/pods/default/p0")
+
+	b.Run("success-delete-range", func(b *testing.B) {
+		backend := &fakeDeleteBackend{
+			resp: &proto.DeleteResponse{
+				Header: &proto.ResponseHeader{
+					Revision: 123,
+				},
+				Succeeded: true,
+				Kv: &proto.KeyValue{
+					Key:      key,
+					Value:    []byte("payload"),
+					Revision: 101,
+				},
+			},
+		}
+		shim := NewBackendShim(backend, nil)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			resp, err := shim.Delete(ctx, key, 101)
+			if err != nil {
+				b.Fatalf("delete failed: %v", err)
+			}
+			benchmarkDeleteResp = resp
+		}
+	})
+
+	b.Run("conflict-range", func(b *testing.B) {
+		backend := &fakeDeleteBackend{
+			resp: &proto.DeleteResponse{
+				Header: &proto.ResponseHeader{
+					Revision: 456,
+				},
+				Succeeded: false,
+				Kv: &proto.KeyValue{
+					Key:      key,
+					Value:    []byte("latest"),
+					Revision: 202,
+				},
+			},
+		}
+		shim := NewBackendShim(backend, nil)
+		b.ReportAllocs()
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			resp, err := shim.Delete(ctx, key, 101)
+			if err != nil {
+				b.Fatalf("delete failed: %v", err)
+			}
+			benchmarkDeleteResp = resp
+		}
+	})
+}

--- a/pkg/server/etcd/watch.go
+++ b/pkg/server/etcd/watch.go
@@ -110,6 +110,19 @@ func (s *RPCServer) Watch(ws etcdserverpb.Watch_WatchServer) error {
 			s.metricCli.EmitCounter("watch.client.cancel", 1)
 			klog.InfoS("receive watch cancel request", "id", w.id, "watchID", cancelRequest.GetWatchId())
 			w.Cancel(msg.GetCancelRequest().WatchId, nil, false)
+		} else if msg.GetProgressRequest() != nil {
+			s.metricCli.EmitCounter("watch.request.progress", 1)
+			revision := int64(s.backend.GetCurrentRevision())
+			// etcd uses watch ID -1 to indicate a broadcast progress notification.
+			if err := ws.Send(&etcdserverpb.WatchResponse{
+				Header: &etcdserverpb.ResponseHeader{
+					Revision: revision,
+				},
+				WatchId: -1,
+			}); err != nil {
+				klog.ErrorS(err, "watch send progress response err", "watcher", w.id, "revision", revision)
+				return err
+			}
 		} else {
 			s.metricCli.EmitCounter("watch.request.unsupported", 1)
 			klog.Info("watch receive message unsupported type")

--- a/test/benchmark/kind/compare.sh
+++ b/test/benchmark/kind/compare.sh
@@ -1,0 +1,352 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+K8S_IMAGE="${K8S_IMAGE:-m.daocloud.io/docker.io/kindest/node:v1.35.0}"
+CLUSTER_PREFIX="${CLUSTER_PREFIX:-kb-bench}"
+KEEP_CLUSTERS="${KEEP_CLUSTERS:-false}"
+
+BUILD_TARGET="${BUILD_TARGET:-badger}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+KUBEBRAIN_GOOS="${KUBEBRAIN_GOOS:-linux}"
+KUBEBRAIN_GOARCH="${KUBEBRAIN_GOARCH:-}"
+KUBEBRAIN_CGO_ENABLED="${KUBEBRAIN_CGO_ENABLED:-0}"
+KUBEBRAIN_KEY_PREFIX="${KUBEBRAIN_KEY_PREFIX:-}"
+KUBEBRAIN_PORT="${KUBEBRAIN_PORT:-3379}"
+KUBEBRAIN_PEER_PORT="${KUBEBRAIN_PEER_PORT:-3380}"
+KUBEBRAIN_INFO_PORT="${KUBEBRAIN_INFO_PORT:-3381}"
+
+BENCH_NAMESPACE="${BENCH_NAMESPACE:-kb-bench}"
+BENCH_OPS="${BENCH_OPS:-200}"
+BENCH_CONCURRENCY="${BENCH_CONCURRENCY:-8}"
+BENCH_WARMUP="${BENCH_WARMUP:-20}"
+
+RESULTS_DIR="${RESULTS_DIR:-test/benchmark/kind/results}"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+RESULT_FILE="${RESULTS_DIR}/kind-compare-${TIMESTAMP}.tsv"
+
+CURRENT_NODE=""
+declare -a CREATED_CLUSTERS=()
+
+log() {
+  printf '[kind-bench] %s\n' "$*"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+now_ms() {
+  python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+}
+
+cleanup_cluster() {
+  local cluster="$1"
+  if [[ "${KEEP_CLUSTERS}" == "true" ]]; then
+    log "KEEP_CLUSTERS=true, skip deleting ${cluster}"
+    return
+  fi
+  kind delete cluster --name "${cluster}" >/dev/null 2>&1 || true
+}
+
+cleanup_all() {
+  local rc=$1
+  if [[ $rc -ne 0 ]]; then
+    log "benchmark failed, collecting simple debug info"
+    if [[ -n "${CURRENT_NODE}" ]]; then
+      docker exec "${CURRENT_NODE}" sh -lc "if [ -f /var/log/kubebrain.log ]; then tail -n 200 /var/log/kubebrain.log; fi" || true
+    fi
+  fi
+  for c in "${CREATED_CLUSTERS[@]:-}"; do
+    cleanup_cluster "$c"
+  done
+  exit "$rc"
+}
+
+trap 'cleanup_all $?' EXIT
+
+wait_apiserver_ready() {
+  local context="$1"
+  for _ in $(seq 1 120); do
+    if kubectl --context "${context}" get --raw='/readyz' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  kubectl --context "${context}" get --raw='/readyz' >/dev/null
+}
+
+create_cluster() {
+  local cluster="$1"
+  if kind get clusters | grep -qx "${cluster}"; then
+    kind delete cluster --name "${cluster}" >/dev/null 2>&1 || true
+  fi
+  kind create cluster --name "${cluster}" --image "${K8S_IMAGE}" >/dev/null
+  CREATED_CLUSTERS+=("${cluster}")
+}
+
+detect_node_arch() {
+  local node="$1"
+  local raw
+  raw="$(docker exec "${node}" uname -m | tr -d '\r\n')"
+  case "${raw}" in
+  aarch64 | arm64)
+    echo "arm64"
+    ;;
+  x86_64 | amd64)
+    echo "amd64"
+    ;;
+  *)
+    echo "unsupported node architecture: ${raw}" >&2
+    return 1
+    ;;
+  esac
+}
+
+build_kubebrain_binary() {
+  local node="$1"
+  if [[ "${SKIP_BUILD}" == "true" ]]; then
+    return
+  fi
+  local goarch="${KUBEBRAIN_GOARCH}"
+  if [[ -z "${goarch}" ]]; then
+    goarch="$(detect_node_arch "${node}")"
+  fi
+  log "building kube-brain: GOOS=${KUBEBRAIN_GOOS} GOARCH=${goarch} CGO_ENABLED=${KUBEBRAIN_CGO_ENABLED}"
+  GOOS="${KUBEBRAIN_GOOS}" GOARCH="${goarch}" CGO_ENABLED="${KUBEBRAIN_CGO_ENABLED}" make "${BUILD_TARGET}" >/dev/null
+}
+
+setup_kubebrain() {
+  local cluster="$1"
+  local context="$2"
+
+  local node
+  node="$(kind get nodes --name "${cluster}" | grep control-plane | head -n1)"
+  if [[ -z "${node}" ]]; then
+    echo "failed to find control-plane node for ${cluster}" >&2
+    return 1
+  fi
+  CURRENT_NODE="${node}"
+
+  build_kubebrain_binary "${node}"
+  if [[ ! -x "./bin/kube-brain" ]]; then
+    echo "binary not found: ./bin/kube-brain" >&2
+    return 1
+  fi
+
+  docker cp ./bin/kube-brain "${node}:/usr/local/bin/kube-brain"
+  docker exec "${node}" sh -lc "
+set -eu
+mkdir -p /var/lib/kubebrain /var/log
+if pgrep -x kube-brain >/dev/null 2>&1; then
+  pkill -x kube-brain || true
+fi
+nohup /usr/local/bin/kube-brain \
+  --data-dir=/var/lib/kubebrain \
+  --key-prefix='${KUBEBRAIN_KEY_PREFIX}' \
+  --compatible-with-etcd=true \
+  --port=${KUBEBRAIN_PORT} \
+  --peer-port=${KUBEBRAIN_PEER_PORT} \
+  --info-port=${KUBEBRAIN_INFO_PORT} \
+  >/var/log/kubebrain.log 2>&1 &
+"
+
+  docker exec "${node}" sh -lc "
+set -eu
+for _ in \$(seq 1 20); do
+  if pgrep -x kube-brain >/dev/null 2>&1; then
+    exit 0
+  fi
+  sleep 1
+done
+echo 'kube-brain process did not start' >&2
+if [ -f /var/log/kubebrain.log ]; then
+  tail -n 200 /var/log/kubebrain.log >&2
+fi
+exit 1
+"
+
+  docker exec "${node}" sh -lc "
+set -eu
+manifest=/etc/kubernetes/manifests/kube-apiserver.yaml
+cp \"\$manifest\" \"\${manifest}.bak\"
+sed -i -E 's#--etcd-servers=https://[^ ]+#--etcd-servers=http://127.0.0.1:${KUBEBRAIN_PORT}#' \"\$manifest\"
+sed -i '/--etcd-cafile=/d;/--etcd-certfile=/d;/--etcd-keyfile=/d' \"\$manifest\"
+"
+
+  wait_apiserver_ready "${context}"
+}
+
+run_single_op() {
+  local context="$1"
+  local ns="$2"
+  local name="$3"
+
+  kubectl --context "${context}" -n "${ns}" create configmap "${name}" --from-literal=v=1 >/dev/null 2>&1
+  kubectl --context "${context}" -n "${ns}" patch configmap "${name}" -p '{"data":{"v":"2"}}' >/dev/null 2>&1
+  kubectl --context "${context}" -n "${ns}" delete configmap "${name}" --wait=true >/dev/null 2>&1
+}
+
+run_worker() {
+  local context="$1"
+  local ns="$2"
+  local run_id="$3"
+  local worker="$4"
+  local total_ops="$5"
+  local step="$6"
+  local latency_file="$7"
+  local stat_file="$8"
+
+  local ok=0
+  local fail=0
+  local i
+  for ((i=worker; i<=total_ops; i+=step)); do
+    local name="cm-${run_id}-${worker}-${i}"
+    local begin end
+    begin="$(now_ms)"
+    if run_single_op "${context}" "${ns}" "${name}"; then
+      end="$(now_ms)"
+      echo $((end - begin)) >>"${latency_file}"
+      ok=$((ok + 1))
+    else
+      kubectl --context "${context}" -n "${ns}" delete configmap "${name}" --ignore-not-found=true >/dev/null 2>&1 || true
+      fail=$((fail + 1))
+    fi
+  done
+  echo "${ok} ${fail}" >"${stat_file}"
+}
+
+summarize_latency() {
+  local lat_file="$1"
+  local sorted="${lat_file}.sorted"
+  sort -n "${lat_file}" >"${sorted}"
+  local n
+  n="$(wc -l <"${sorted}" | tr -d ' ')"
+  if [[ "${n}" == "0" ]]; then
+    echo "0 0 0 0"
+    return
+  fi
+  local p50_idx=$(( (50 * n + 99) / 100 ))
+  local p90_idx=$(( (90 * n + 99) / 100 ))
+  local p99_idx=$(( (99 * n + 99) / 100 ))
+  local p50 p90 p99 avg
+  p50="$(awk -v i="${p50_idx}" 'NR==i {print; exit}' "${sorted}")"
+  p90="$(awk -v i="${p90_idx}" 'NR==i {print; exit}' "${sorted}")"
+  p99="$(awk -v i="${p99_idx}" 'NR==i {print; exit}' "${sorted}")"
+  avg="$(awk '{s+=$1} END {if (NR==0) print 0; else printf "%.2f", s/NR}' "${sorted}")"
+  echo "${p50} ${p90} ${p99} ${avg}"
+}
+
+run_benchmark_case() {
+  local mode="$1"
+  local context="$2"
+
+  kubectl --context "${context}" create namespace "${BENCH_NAMESPACE}" --dry-run=client -o yaml | kubectl --context "${context}" apply -f - >/dev/null
+
+  if (( BENCH_WARMUP > 0 )); then
+    log "${mode}: warmup ${BENCH_WARMUP} ops"
+    local i
+    for ((i=1; i<=BENCH_WARMUP; i++)); do
+      run_single_op "${context}" "${BENCH_NAMESPACE}" "warmup-${mode}-${i}" || true
+    done
+  fi
+
+  log "${mode}: running benchmark ops=${BENCH_OPS} concurrency=${BENCH_CONCURRENCY}"
+  local run_id="${mode}-${TIMESTAMP}"
+  local workdir
+  workdir="$(mktemp -d)"
+  local start_ms end_ms
+  start_ms="$(now_ms)"
+
+  local w
+  for ((w=1; w<=BENCH_CONCURRENCY; w++)); do
+    run_worker "${context}" "${BENCH_NAMESPACE}" "${run_id}" "${w}" "${BENCH_OPS}" "${BENCH_CONCURRENCY}" "${workdir}/lat-${w}.txt" "${workdir}/stat-${w}.txt" &
+  done
+  wait
+
+  end_ms="$(now_ms)"
+  local duration_ms=$((end_ms - start_ms))
+
+  cat "${workdir}"/lat-*.txt 2>/dev/null >"${workdir}/all.lat" || true
+  local ok_total=0
+  local fail_total=0
+  for f in "${workdir}"/stat-*.txt; do
+    [[ -f "${f}" ]] || continue
+    local ok fail
+    ok="$(awk '{print $1}' "${f}")"
+    fail="$(awk '{print $2}' "${f}")"
+    ok_total=$((ok_total + ok))
+    fail_total=$((fail_total + fail))
+  done
+
+  local p50 p90 p99 avg
+  read -r p50 p90 p99 avg < <(summarize_latency "${workdir}/all.lat")
+  local ops_per_sec
+  ops_per_sec="$(awk -v n="${ok_total}" -v d="${duration_ms}" 'BEGIN {if (d<=0) print "0"; else printf "%.2f", n*1000/d}')"
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "${mode}" "${BENCH_OPS}" "${BENCH_CONCURRENCY}" "${ok_total}" "${fail_total}" "${duration_ms}" "${ops_per_sec}" "${avg}" "${p50}" "${p90}" "${p99}" >>"${RESULT_FILE}"
+
+  rm -rf "${workdir}"
+}
+
+print_result_table() {
+  local file="$1"
+  echo
+  echo "Result file: ${file}"
+  echo
+  awk -F '\t' 'BEGIN {
+    printf "| mode | ops | concurrency | success | fail | duration_ms | ops/s | avg_ms | p50_ms | p90_ms | p99_ms |\n";
+    printf "|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|\n";
+  }
+  NR>1 {
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11;
+  }' "${file}"
+}
+
+main() {
+  require_cmd kind
+  require_cmd kubectl
+  require_cmd docker
+  require_cmd make
+  require_cmd python3
+  require_cmd awk
+  require_cmd sort
+
+  if [[ -n "${KUBEBRAIN_KEY_PREFIX}" && "${KUBEBRAIN_KEY_PREFIX}" == */ ]]; then
+    echo "invalid KUBEBRAIN_KEY_PREFIX=${KUBEBRAIN_KEY_PREFIX}: trailing '/' is not allowed" >&2
+    exit 1
+  fi
+
+  mkdir -p "${RESULTS_DIR}"
+  printf "mode\tops\tconcurrency\tsuccess\tfail\tduration_ms\tops_per_sec\tavg_ms\tp50_ms\tp90_ms\tp99_ms\n" >"${RESULT_FILE}"
+
+  local etcd_cluster="${CLUSTER_PREFIX}-etcd"
+  local kb_cluster="${CLUSTER_PREFIX}-kubebrain"
+
+  log "case etcd: creating cluster ${etcd_cluster}"
+  create_cluster "${etcd_cluster}"
+  CURRENT_NODE=""
+  run_benchmark_case "etcd" "kind-${etcd_cluster}"
+  cleanup_cluster "${etcd_cluster}"
+
+  log "case kubebrain: creating cluster ${kb_cluster}"
+  create_cluster "${kb_cluster}"
+  setup_kubebrain "${kb_cluster}" "kind-${kb_cluster}"
+  run_benchmark_case "kubebrain" "kind-${kb_cluster}"
+  cleanup_cluster "${kb_cluster}"
+
+  print_result_table "${RESULT_FILE}"
+  log "benchmark completed"
+}
+
+main "$@"

--- a/test/benchmark/kind/results/.gitignore
+++ b/test/benchmark/kind/results/.gitignore
@@ -1,0 +1,2 @@
+*.tsv
+!.gitignore

--- a/test/benchmark/kwok/compare.sh
+++ b/test/benchmark/kwok/compare.sh
@@ -1,0 +1,378 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+K8S_IMAGE="${K8S_IMAGE:-m.daocloud.io/docker.io/kindest/node:v1.35.0}"
+RUNTIME="${RUNTIME:-kind}"
+CLUSTER_PREFIX="${CLUSTER_PREFIX:-kb-kwok-bench}"
+KEEP_CLUSTERS="${KEEP_CLUSTERS:-false}"
+
+BUILD_TARGET="${BUILD_TARGET:-badger}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+KUBEBRAIN_GOOS="${KUBEBRAIN_GOOS:-linux}"
+KUBEBRAIN_GOARCH="${KUBEBRAIN_GOARCH:-}"
+KUBEBRAIN_CGO_ENABLED="${KUBEBRAIN_CGO_ENABLED:-0}"
+KUBEBRAIN_KEY_PREFIX="${KUBEBRAIN_KEY_PREFIX:-}"
+KUBEBRAIN_PORT="${KUBEBRAIN_PORT:-3379}"
+KUBEBRAIN_PEER_PORT="${KUBEBRAIN_PEER_PORT:-3380}"
+KUBEBRAIN_INFO_PORT="${KUBEBRAIN_INFO_PORT:-3381}"
+
+BENCH_NAMESPACE="${BENCH_NAMESPACE:-kwok-bench}"
+BENCH_DEPLOYMENT="${BENCH_DEPLOYMENT:-kwok-bench-pods}"
+FAKE_NODES="${FAKE_NODES:-100}"
+PODS="${PODS:-10000}"
+POLL_INTERVAL_SECONDS="${POLL_INTERVAL_SECONDS:-5}"
+TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-1800}"
+
+RESULTS_DIR="${RESULTS_DIR:-test/benchmark/kwok/results}"
+TIMESTAMP="$(date +%Y%m%d-%H%M%S)"
+RESULT_FILE="${RESULTS_DIR}/kwok-compare-${TIMESTAMP}.tsv"
+
+CURRENT_CLUSTER=""
+CURRENT_KIND_CLUSTER=""
+CURRENT_MODE=""
+CURRENT_NODE=""
+declare -a CREATED_CLUSTERS=()
+
+log() {
+  printf '[kwok-bench] %s\n' "$*"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+now_ms() {
+  python3 - <<'PY'
+import time
+print(int(time.time() * 1000))
+PY
+}
+
+context_name() {
+  local cluster="$1"
+  echo "kwok-${cluster}"
+}
+
+kind_cluster_name() {
+  local cluster="$1"
+  echo "kwok-${cluster}"
+}
+
+cleanup_cluster() {
+  local cluster="$1"
+  if [[ "${KEEP_CLUSTERS}" == "true" ]]; then
+    log "KEEP_CLUSTERS=true, skip deleting cluster ${cluster}"
+    return
+  fi
+  kwokctl delete cluster --name "${cluster}" >/dev/null 2>&1 || true
+}
+
+dump_debug() {
+  local cluster="$1"
+  local mode="$2"
+  log "debug for mode=${mode}, cluster=${cluster}"
+  local context
+  context="$(context_name "${cluster}")"
+  kubectl --context "${context}" get nodes -o wide || true
+  kubectl --context "${context}" get pods -A || true
+  kwokctl logs kube-apiserver --name "${cluster}" --tail 200 || true
+  kwokctl logs kube-scheduler --name "${cluster}" --tail 200 || true
+  if [[ "${mode}" == "kubebrain" && -n "${CURRENT_NODE}" ]]; then
+    docker exec "${CURRENT_NODE}" sh -lc "if [ -f /var/log/kubebrain.log ]; then tail -n 200 /var/log/kubebrain.log; else echo 'kubebrain log file not found'; fi" || true
+  fi
+}
+
+cleanup_all() {
+  local rc=$1
+  if [[ $rc -ne 0 && -n "${CURRENT_CLUSTER}" ]]; then
+    dump_debug "${CURRENT_CLUSTER}" "${CURRENT_MODE:-unknown}"
+  fi
+  for c in "${CREATED_CLUSTERS[@]:-}"; do
+    cleanup_cluster "$c"
+  done
+  exit "$rc"
+}
+
+trap 'cleanup_all $?' EXIT
+
+wait_apiserver_ready() {
+  local context="$1"
+  for _ in $(seq 1 120); do
+    if kubectl --context "${context}" get --raw='/readyz' >/dev/null 2>&1; then
+      return 0
+    fi
+    sleep 2
+  done
+  kubectl --context "${context}" get --raw='/readyz' >/dev/null
+}
+
+create_kwok_cluster() {
+  local cluster="$1"
+  log "creating kwok cluster ${cluster} runtime=${RUNTIME} image=${K8S_IMAGE}"
+  local args=(create cluster --name "${cluster}" --runtime "${RUNTIME}")
+  if [[ "${RUNTIME}" == "kind" && -n "${K8S_IMAGE}" ]]; then
+    args+=(--kind-node-image "${K8S_IMAGE}")
+  fi
+  kwokctl "${args[@]}" >/dev/null
+  CREATED_CLUSTERS+=("${cluster}")
+  local context
+  context="$(context_name "${cluster}")"
+  wait_apiserver_ready "${context}"
+}
+
+detect_node_arch() {
+  local node="$1"
+  local raw
+  raw="$(docker exec "${node}" uname -m | tr -d '\r\n')"
+  case "${raw}" in
+  aarch64 | arm64)
+    echo "arm64"
+    ;;
+  x86_64 | amd64)
+    echo "amd64"
+    ;;
+  *)
+    echo "unsupported node architecture: ${raw}" >&2
+    return 1
+    ;;
+  esac
+}
+
+build_kubebrain_binary() {
+  local node="$1"
+  if [[ "${SKIP_BUILD}" == "true" ]]; then
+    return
+  fi
+  local goarch="${KUBEBRAIN_GOARCH}"
+  if [[ -z "${goarch}" ]]; then
+    goarch="$(detect_node_arch "${node}")"
+  fi
+  log "building kube-brain: GOOS=${KUBEBRAIN_GOOS} GOARCH=${goarch} CGO_ENABLED=${KUBEBRAIN_CGO_ENABLED}"
+  GOOS="${KUBEBRAIN_GOOS}" GOARCH="${goarch}" CGO_ENABLED="${KUBEBRAIN_CGO_ENABLED}" make "${BUILD_TARGET}" >/dev/null
+}
+
+setup_kubebrain_proxy() {
+  local cluster="$1"
+  local context="$2"
+  local kind_cluster
+  kind_cluster="$(kind_cluster_name "${cluster}")"
+  local node
+  node="$(kind get nodes --name "${kind_cluster}" | grep control-plane | head -n1)"
+  if [[ -z "${node}" ]]; then
+    echo "failed to find control-plane node for kind cluster ${kind_cluster}" >&2
+    return 1
+  fi
+  CURRENT_NODE="${node}"
+
+  build_kubebrain_binary "${node}"
+  if [[ ! -x "./bin/kube-brain" ]]; then
+    echo "binary not found: ./bin/kube-brain" >&2
+    return 1
+  fi
+
+  docker cp ./bin/kube-brain "${node}:/usr/local/bin/kube-brain"
+  docker exec "${node}" sh -lc "
+set -eu
+mkdir -p /var/lib/kubebrain /var/log
+if pgrep -x kube-brain >/dev/null 2>&1; then
+  pkill -x kube-brain || true
+fi
+nohup /usr/local/bin/kube-brain \
+  --data-dir=/var/lib/kubebrain \
+  --key-prefix='${KUBEBRAIN_KEY_PREFIX}' \
+  --compatible-with-etcd=true \
+  --port=${KUBEBRAIN_PORT} \
+  --peer-port=${KUBEBRAIN_PEER_PORT} \
+  --info-port=${KUBEBRAIN_INFO_PORT} \
+  >/var/log/kubebrain.log 2>&1 &
+"
+
+  docker exec "${node}" sh -lc "
+set -eu
+for _ in \$(seq 1 20); do
+  if pgrep -x kube-brain >/dev/null 2>&1; then
+    exit 0
+  fi
+  sleep 1
+done
+echo 'kube-brain process did not start' >&2
+if [ -f /var/log/kubebrain.log ]; then
+  tail -n 200 /var/log/kubebrain.log >&2
+fi
+exit 1
+"
+
+  docker exec "${node}" sh -lc "
+set -eu
+manifest=/etc/kubernetes/manifests/kube-apiserver.yaml
+cp \"\$manifest\" \"\${manifest}.bak\"
+sed -i -E 's#--etcd-servers=https://[^ ]+#--etcd-servers=http://127.0.0.1:${KUBEBRAIN_PORT}#' \"\$manifest\"
+sed -i '/--etcd-cafile=/d;/--etcd-certfile=/d;/--etcd-keyfile=/d' \"\$manifest\"
+"
+
+  wait_apiserver_ready "${context}"
+}
+
+prepare_fake_nodes() {
+  local cluster="$1"
+  local context="$2"
+  kwokctl scale node --name "${cluster}" --replicas "${FAKE_NODES}" >/dev/null
+  local ready=0
+  for _ in $(seq 1 120); do
+    ready="$(kubectl --context "${context}" get nodes --no-headers 2>/dev/null | awk '$2 ~ /Ready/ {c++} END {print c+0}')"
+    if (( ready >= FAKE_NODES )); then
+      return 0
+    fi
+    sleep 2
+  done
+  echo "not enough ready nodes: expected >=${FAKE_NODES}, got ${ready}" >&2
+  return 1
+}
+
+apply_benchmark_workload() {
+  local context="$1"
+  kubectl --context "${context}" create namespace "${BENCH_NAMESPACE}" --dry-run=client -o yaml | kubectl --context "${context}" apply -f - >/dev/null
+  cat <<EOF | kubectl --context "${context}" apply -f - >/dev/null
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ${BENCH_DEPLOYMENT}
+  namespace: ${BENCH_NAMESPACE}
+spec:
+  replicas: ${PODS}
+  selector:
+    matchLabels:
+      app: ${BENCH_DEPLOYMENT}
+  template:
+    metadata:
+      labels:
+        app: ${BENCH_DEPLOYMENT}
+    spec:
+      tolerations:
+      - key: "kwok.x-k8s.io/node"
+        operator: "Exists"
+        effect: "NoSchedule"
+      containers:
+      - name: fake
+        image: registry.k8s.io/pause:3.10
+        resources:
+          requests:
+            cpu: "5m"
+            memory: "8Mi"
+EOF
+}
+
+wait_running_pods() {
+  local context="$1"
+  local expected="$2"
+  local namespace="$3"
+  local start_ms="$4"
+  local timeout_ms=$((TIMEOUT_SECONDS * 1000))
+
+  while true; do
+    local now elapsed running
+    now="$(now_ms)"
+    elapsed=$((now - start_ms))
+    running="$(kubectl --context "${context}" -n "${namespace}" get pods --field-selector=status.phase=Running --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+    if (( running >= expected )); then
+      echo "${running} ${elapsed}"
+      return 0
+    fi
+    if (( elapsed > timeout_ms )); then
+      echo "${running} ${elapsed}"
+      return 1
+    fi
+    sleep "${POLL_INTERVAL_SECONDS}"
+  done
+}
+
+run_case() {
+  local mode="$1"
+  local cluster="$2"
+
+  CURRENT_MODE="${mode}"
+  CURRENT_CLUSTER="${cluster}"
+  CURRENT_KIND_CLUSTER="$(kind_cluster_name "${cluster}")"
+
+  create_kwok_cluster "${cluster}"
+  local context
+  context="$(context_name "${cluster}")"
+
+  if [[ "${mode}" == "kubebrain" ]]; then
+    setup_kubebrain_proxy "${cluster}" "${context}"
+  fi
+
+  prepare_fake_nodes "${cluster}" "${context}"
+  apply_benchmark_workload "${context}"
+
+  local start_ms
+  start_ms="$(now_ms)"
+  local running elapsed_ms status
+  if read -r running elapsed_ms < <(wait_running_pods "${context}" "${PODS}" "${BENCH_NAMESPACE}" "${start_ms}"); then
+    status="ok"
+  else
+    status="timeout"
+  fi
+
+  local throughput
+  throughput="$(awk -v p="${running}" -v d="${elapsed_ms}" 'BEGIN {if (d<=0) print "0"; else printf "%.2f", p*1000/d}')"
+  local nodes
+  nodes="$(kubectl --context "${context}" get nodes --no-headers 2>/dev/null | wc -l | tr -d ' ')"
+
+  printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+    "${mode}" "${FAKE_NODES}" "${PODS}" "${nodes}" "${running}" "${elapsed_ms}" "${throughput}" "${status}" "${context}" >>"${RESULT_FILE}"
+
+  if [[ "${status}" != "ok" ]]; then
+    echo "benchmark case ${mode} timed out after ${elapsed_ms}ms (running=${running}, target=${PODS})" >&2
+    return 1
+  fi
+
+  cleanup_cluster "${cluster}"
+}
+
+print_results() {
+  local file="$1"
+  echo
+  echo "Result file: ${file}"
+  echo
+  awk -F '\t' 'BEGIN {
+    printf "| mode | fake_nodes_target | pods_target | nodes_seen | pods_running | time_ms | pods/s | status | context |\n";
+    printf "|---|---:|---:|---:|---:|---:|---:|---|---|\n";
+  }
+  NR>1 {
+    printf "| %s | %s | %s | %s | %s | %s | %s | %s | %s |\n", $1,$2,$3,$4,$5,$6,$7,$8,$9;
+  }' "${file}"
+}
+
+main() {
+  require_cmd kwokctl
+  require_cmd kind
+  require_cmd kubectl
+  require_cmd docker
+  require_cmd make
+  require_cmd python3
+  require_cmd awk
+  require_cmd wc
+
+  if [[ -n "${KUBEBRAIN_KEY_PREFIX}" && "${KUBEBRAIN_KEY_PREFIX}" == */ ]]; then
+    echo "invalid KUBEBRAIN_KEY_PREFIX=${KUBEBRAIN_KEY_PREFIX}: trailing '/' is not allowed" >&2
+    exit 1
+  fi
+  mkdir -p "${RESULTS_DIR}"
+  printf "mode\tfake_nodes_target\tpods_target\tnodes_seen\tpods_running\ttime_ms\tpods_per_sec\tstatus\tcontext\n" >"${RESULT_FILE}"
+
+  run_case "etcd" "${CLUSTER_PREFIX}-etcd"
+  run_case "kubebrain" "${CLUSTER_PREFIX}-kubebrain"
+
+  print_results "${RESULT_FILE}"
+  log "kwok benchmark comparison completed"
+}
+
+main "$@"

--- a/test/benchmark/kwok/compare.sh
+++ b/test/benchmark/kwok/compare.sh
@@ -314,10 +314,12 @@ run_case() {
 
   local start_ms
   start_ms="$(now_ms)"
-  local running elapsed_ms status
-  if read -r running elapsed_ms < <(wait_running_pods "${context}" "${PODS}" "${BENCH_NAMESPACE}" "${start_ms}"); then
+  local running elapsed_ms status wait_out
+  if wait_out="$(wait_running_pods "${context}" "${PODS}" "${BENCH_NAMESPACE}" "${start_ms}")"; then
+    read -r running elapsed_ms <<<"${wait_out}"
     status="ok"
   else
+    read -r running elapsed_ms <<<"${wait_out}"
     status="timeout"
   fi
 

--- a/test/benchmark/kwok/results/.gitignore
+++ b/test/benchmark/kwok/results/.gitignore
@@ -1,0 +1,2 @@
+*.tsv
+!.gitignore

--- a/test/e2e/kind/run.sh
+++ b/test/e2e/kind/run.sh
@@ -20,6 +20,7 @@ KUBEBRAIN_INFO_PORT="${KUBEBRAIN_INFO_PORT:-3381}"
 E2E_NAMESPACE="${E2E_NAMESPACE:-kb-e2e}"
 KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
 SKIP_BUILD="${SKIP_BUILD:-false}"
+KUBEBRAIN_KEY_PREFIX="${KUBEBRAIN_KEY_PREFIX:-}"
 
 CONTROL_PLANE_NODE=""
 
@@ -39,7 +40,7 @@ dump_debug() {
   kubectl --context "${KIND_CONTEXT}" get nodes -o wide || true
   kubectl --context "${KIND_CONTEXT}" get pods -A || true
   if [[ -n "${CONTROL_PLANE_NODE}" ]]; then
-    docker exec "${CONTROL_PLANE_NODE}" sh -lc "tail -n 200 /var/log/kubebrain.log" || true
+    docker exec "${CONTROL_PLANE_NODE}" sh -lc "if [ -f /var/log/kubebrain.log ]; then tail -n 200 /var/log/kubebrain.log; else echo 'kubebrain log file not found'; fi" || true
   fi
 }
 
@@ -58,6 +59,11 @@ require_cmd kind
 require_cmd kubectl
 require_cmd docker
 require_cmd make
+
+if [[ -n "${KUBEBRAIN_KEY_PREFIX}" && "${KUBEBRAIN_KEY_PREFIX}" == */ ]]; then
+  echo "invalid KUBEBRAIN_KEY_PREFIX=${KUBEBRAIN_KEY_PREFIX}: trailing '/' is not allowed" >&2
+  exit 1
+fi
 
 if kind get clusters | grep -qx "${CLUSTER_NAME}"; then
   log "cluster ${CLUSTER_NAME} already exists, recreating"
@@ -111,15 +117,32 @@ log "starting kube-brain inside kind node"
 docker exec "${CONTROL_PLANE_NODE}" sh -lc "
 set -eu
 mkdir -p /var/lib/kubebrain /var/log
-pkill -f '/usr/local/bin/kube-brain' >/dev/null 2>&1 || true
+if pgrep -x kube-brain >/dev/null 2>&1; then
+  pkill -x kube-brain || true
+fi
 nohup /usr/local/bin/kube-brain \
   --data-dir=/var/lib/kubebrain \
-  --key-prefix='/' \
+  --key-prefix='${KUBEBRAIN_KEY_PREFIX}' \
   --compatible-with-etcd=true \
   --port=${KUBEBRAIN_PORT} \
   --peer-port=${KUBEBRAIN_PEER_PORT} \
   --info-port=${KUBEBRAIN_INFO_PORT} \
   >/var/log/kubebrain.log 2>&1 &
+"
+
+docker exec "${CONTROL_PLANE_NODE}" sh -lc "
+set -eu
+for _ in \$(seq 1 20); do
+  if pgrep -x kube-brain >/dev/null 2>&1; then
+    exit 0
+  fi
+  sleep 1
+done
+echo 'kube-brain process did not start' >&2
+if [ -f /var/log/kubebrain.log ]; then
+  tail -n 200 /var/log/kubebrain.log >&2
+fi
+exit 1
 "
 
 log "patching kube-apiserver manifest to use kube-brain"

--- a/test/e2e/kind/run.sh
+++ b/test/e2e/kind/run.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT_DIR}"
+
+CLUSTER_NAME="${CLUSTER_NAME:-kb-e2e}"
+K8S_IMAGE="${K8S_IMAGE:-kindest/node:v1.35.0}"
+KIND_CONTEXT="kind-${CLUSTER_NAME}"
+BUILD_TARGET="${BUILD_TARGET:-badger}"
+
+KUBEBRAIN_PORT="${KUBEBRAIN_PORT:-3379}"
+KUBEBRAIN_PEER_PORT="${KUBEBRAIN_PEER_PORT:-3380}"
+KUBEBRAIN_INFO_PORT="${KUBEBRAIN_INFO_PORT:-3381}"
+
+E2E_NAMESPACE="${E2E_NAMESPACE:-kb-e2e}"
+KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
+SKIP_BUILD="${SKIP_BUILD:-false}"
+
+CONTROL_PLANE_NODE=""
+
+log() {
+  printf '[kind-e2e] %s\n' "$*"
+}
+
+require_cmd() {
+  if ! command -v "$1" >/dev/null 2>&1; then
+    echo "missing required command: $1" >&2
+    exit 1
+  fi
+}
+
+dump_debug() {
+  log "dumping debug info"
+  kubectl --context "${KIND_CONTEXT}" get nodes -o wide || true
+  kubectl --context "${KIND_CONTEXT}" get pods -A || true
+  if [[ -n "${CONTROL_PLANE_NODE}" ]]; then
+    docker exec "${CONTROL_PLANE_NODE}" sh -lc "tail -n 200 /var/log/kubebrain.log" || true
+  fi
+}
+
+cleanup() {
+  if [[ "${KEEP_CLUSTER}" == "true" ]]; then
+    log "KEEP_CLUSTER=true, skip deleting kind cluster ${CLUSTER_NAME}"
+    return
+  fi
+  log "deleting kind cluster ${CLUSTER_NAME}"
+  kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
+}
+
+trap 'rc=$?; if [[ $rc -ne 0 ]]; then dump_debug; fi; cleanup; exit $rc' EXIT
+
+require_cmd kind
+require_cmd kubectl
+require_cmd docker
+require_cmd make
+
+if kind get clusters | grep -qx "${CLUSTER_NAME}"; then
+  log "cluster ${CLUSTER_NAME} already exists, recreating"
+  kind delete cluster --name "${CLUSTER_NAME}"
+fi
+
+log "creating kind cluster ${CLUSTER_NAME} (${K8S_IMAGE})"
+kind create cluster --name "${CLUSTER_NAME}" --image "${K8S_IMAGE}"
+
+if [[ "${SKIP_BUILD}" != "true" ]]; then
+  log "building kube-brain binary using make ${BUILD_TARGET}"
+  make "${BUILD_TARGET}"
+fi
+
+if [[ ! -x "./bin/kube-brain" ]]; then
+  echo "binary not found or not executable: ./bin/kube-brain" >&2
+  exit 1
+fi
+
+CONTROL_PLANE_NODE="$(kind get nodes --name "${CLUSTER_NAME}" | grep 'control-plane' | head -n1)"
+if [[ -z "${CONTROL_PLANE_NODE}" ]]; then
+  echo "failed to find kind control-plane node" >&2
+  exit 1
+fi
+
+log "copying kube-brain binary to ${CONTROL_PLANE_NODE}"
+docker cp ./bin/kube-brain "${CONTROL_PLANE_NODE}:/usr/local/bin/kube-brain"
+
+log "starting kube-brain inside kind node"
+docker exec "${CONTROL_PLANE_NODE}" sh -lc "
+set -eu
+mkdir -p /var/lib/kubebrain /var/log
+pkill -f '/usr/local/bin/kube-brain' >/dev/null 2>&1 || true
+nohup /usr/local/bin/kube-brain \
+  --data-dir=/var/lib/kubebrain \
+  --key-prefix='/' \
+  --compatible-with-etcd=true \
+  --port=${KUBEBRAIN_PORT} \
+  --peer-port=${KUBEBRAIN_PEER_PORT} \
+  --info-port=${KUBEBRAIN_INFO_PORT} \
+  >/var/log/kubebrain.log 2>&1 &
+"
+
+log "patching kube-apiserver manifest to use kube-brain"
+docker exec "${CONTROL_PLANE_NODE}" sh -lc "
+set -eu
+manifest=/etc/kubernetes/manifests/kube-apiserver.yaml
+cp \"\$manifest\" \"\${manifest}.bak\"
+sed -i -E 's#--etcd-servers=https://[^ ]+#--etcd-servers=http://127.0.0.1:${KUBEBRAIN_PORT}#' \"\$manifest\"
+sed -i '/--etcd-cafile=/d;/--etcd-certfile=/d;/--etcd-keyfile=/d' \"\$manifest\"
+"
+
+log "waiting for kube-apiserver to become ready"
+for _ in $(seq 1 120); do
+  if kubectl --context "${KIND_CONTEXT}" get --raw='/readyz' >/dev/null 2>&1; then
+    break
+  fi
+  sleep 2
+done
+kubectl --context "${KIND_CONTEXT}" get --raw='/readyz' >/dev/null
+
+log "running CRUD smoke tests"
+kubectl --context "${KIND_CONTEXT}" create namespace "${E2E_NAMESPACE}" --dry-run=client -o yaml | kubectl --context "${KIND_CONTEXT}" apply -f -
+kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" create configmap cm-e2e --from-literal=a=1
+kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" patch configmap cm-e2e -p '{"data":{"a":"2"}}'
+actual="$(kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" get configmap cm-e2e -o jsonpath='{.data.a}')"
+if [[ "${actual}" != "2" ]]; then
+  echo "configmap value mismatch, expected 2, got ${actual}" >&2
+  exit 1
+fi
+kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" delete configmap cm-e2e --wait=true
+
+log "running watch smoke test"
+watch_log="$(mktemp)"
+kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" get configmaps -w --request-timeout=20s >"${watch_log}" 2>&1 &
+watch_pid=$!
+sleep 2
+kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" create configmap cm-watch --from-literal=x=1
+kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" delete configmap cm-watch --wait=true
+wait "${watch_pid}" || true
+if ! grep -q 'cm-watch' "${watch_log}"; then
+  echo "watch output does not contain cm-watch" >&2
+  cat "${watch_log}" >&2 || true
+  rm -f "${watch_log}"
+  exit 1
+fi
+rm -f "${watch_log}"
+
+log "validating kube-brain log for severe errors"
+docker exec "${CONTROL_PLANE_NODE}" sh -lc "grep -E 'panic|fatal' /var/log/kubebrain.log && exit 1 || true"
+
+log "e2e passed"

--- a/test/e2e/kind/run.sh
+++ b/test/e2e/kind/run.sh
@@ -6,9 +6,12 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 cd "${ROOT_DIR}"
 
 CLUSTER_NAME="${CLUSTER_NAME:-kb-e2e}"
-K8S_IMAGE="${K8S_IMAGE:-kindest/node:v1.35.0}"
+K8S_IMAGE="${K8S_IMAGE:-m.daocloud.io/docker.io/kindest/node:v1.35.0}"
 KIND_CONTEXT="kind-${CLUSTER_NAME}"
 BUILD_TARGET="${BUILD_TARGET:-badger}"
+KUBEBRAIN_GOOS="${KUBEBRAIN_GOOS:-linux}"
+KUBEBRAIN_GOARCH="${KUBEBRAIN_GOARCH:-}"
+KUBEBRAIN_CGO_ENABLED="${KUBEBRAIN_CGO_ENABLED:-0}"
 
 KUBEBRAIN_PORT="${KUBEBRAIN_PORT:-3379}"
 KUBEBRAIN_PEER_PORT="${KUBEBRAIN_PEER_PORT:-3380}"
@@ -62,21 +65,42 @@ if kind get clusters | grep -qx "${CLUSTER_NAME}"; then
 fi
 
 log "creating kind cluster ${CLUSTER_NAME} (${K8S_IMAGE})"
-kind create cluster --name "${CLUSTER_NAME}" --image "${K8S_IMAGE}"
-
-if [[ "${SKIP_BUILD}" != "true" ]]; then
-  log "building kube-brain binary using make ${BUILD_TARGET}"
-  make "${BUILD_TARGET}"
+kind_create_args=(create cluster --name "${CLUSTER_NAME}")
+if [[ -n "${K8S_IMAGE}" ]]; then
+  kind_create_args+=(--image "${K8S_IMAGE}")
 fi
-
-if [[ ! -x "./bin/kube-brain" ]]; then
-  echo "binary not found or not executable: ./bin/kube-brain" >&2
-  exit 1
-fi
+log "running: kind ${kind_create_args[*]}"
+kind "${kind_create_args[@]}"
 
 CONTROL_PLANE_NODE="$(kind get nodes --name "${CLUSTER_NAME}" | grep 'control-plane' | head -n1)"
 if [[ -z "${CONTROL_PLANE_NODE}" ]]; then
   echo "failed to find kind control-plane node" >&2
+  exit 1
+fi
+
+if [[ "${SKIP_BUILD}" != "true" ]]; then
+  if [[ -z "${KUBEBRAIN_GOARCH}" ]]; then
+    node_arch_raw="$(docker exec "${CONTROL_PLANE_NODE}" uname -m | tr -d '\r\n')"
+    case "${node_arch_raw}" in
+    aarch64 | arm64)
+      KUBEBRAIN_GOARCH="arm64"
+      ;;
+    x86_64 | amd64)
+      KUBEBRAIN_GOARCH="amd64"
+      ;;
+    *)
+      echo "unsupported node architecture: ${node_arch_raw}" >&2
+      exit 1
+      ;;
+    esac
+  fi
+  log "building kube-brain binary using make ${BUILD_TARGET}"
+  log "build target platform: GOOS=${KUBEBRAIN_GOOS} GOARCH=${KUBEBRAIN_GOARCH} CGO_ENABLED=${KUBEBRAIN_CGO_ENABLED}"
+  GOOS="${KUBEBRAIN_GOOS}" GOARCH="${KUBEBRAIN_GOARCH}" CGO_ENABLED="${KUBEBRAIN_CGO_ENABLED}" make "${BUILD_TARGET}"
+fi
+
+if [[ ! -x "./bin/kube-brain" ]]; then
+  echo "binary not found or not executable: ./bin/kube-brain" >&2
   exit 1
 fi
 


### PR DESCRIPTION
#### What type of PR is this?

Try to support v1.35

#### What this PR does / why we need it:

Key changes:

1. Kubernetes/etcd compatibility fixes
  - [pkg/server/etcd/backendshim.go](https://github.com/pacoxu/kubebrain/pull/1/files#diff-0a9f05969e59b957b6452580d4cb5cd23c47351bbfbd04a4eb19bd0884e31e09): adjusts delete txn response shape for newer apiserver expectations.
  - [pkg/server/etcd/watch.go](https://github.com/pacoxu/kubebrain/pull/1/files#diff-8df34776ef4eb04e15bfa2999d39eb9e108f53f9ac1cc19b52e936f5505f74af): adds watch progress request handling.
  - [pkg/backend/txn.go](https://github.com/pacoxu/kubebrain/pull/1/files#diff-6f1ec41ca62f66f95a3f301ebf38eaec96f70570f636f63352967b4d3bdfe8dc): propagates lease/TTL correctly in create/update-create path.
2. Tests and benchmarks for compatibility paths
  - [pkg/server/etcd/backendshim_test.go](https://github.com/pacoxu/kubebrain/pull/1/files#diff-3cfbf949f67011a9be8eab62f2b2fdb8b6b559ca9f8c1ad6426b2d18624f4a8c): adds delete behavior tests and benchmark.
  - [pkg/backend/lease_compat_test.go](https://github.com/pacoxu/kubebrain/pull/1/files#diff-11fe0af9d8d5c18fa552a4d2a6328c5f68267ac8ecbb4863ce34e653847df5f5): adds lease compatibility tests.
3. New e2e and benchmark automation
  - [test/e2e/kind/run.sh](https://github.com/pacoxu/kubebrain/pull/1/files#diff-b9d8e8cbf5f14ff8f95a294605cf0914f816fe4da17d8c2c7faf2eebef8dd0d1): kind e2e flow (build, patch apiserver, CRUD/watch smoke tests).
  - [test/benchmark/kind/compare.sh](https://github.com/pacoxu/kubebrain/pull/1/files#diff-e8dd9cbc40cf7375266b7104aa8d92a12ec4f85f7f08bb91f03b6a2fa766a591): kind etcd vs kubebrain benchmark.
  - [test/benchmark/kwok/compare.sh](https://github.com/pacoxu/kubebrain/pull/1/files#diff-e40f051cc67cb58dde395eb8cb8218d5f371a3dfd2d95f8789282fd1f84e18f1): kwok-based large-scale comparison script.
  - Docs added: [docs/benchmark_kind.md](https://github.com/pacoxu/kubebrain/pull/1/files#diff-338cbcbf5ec8434447be46ec64da1c5ca95ac06ed646fbb0df935d478006ea6d), [docs/benchmark_kwok.md](https://github.com/pacoxu/kubebrain/pull/1/files#diff-e976c8cfb7dbb2b3070fe4fb1d3f5ba337b6846c8d40fa4f72f92895f155a008).
4. Build/dev workflow updates
  - [makefile](https://github.com/pacoxu/kubebrain/pull/1/files#diff-c4f2f85da1f9f6f348f3484a2b5c5a3c5f8d55f56fe84814e6f6586b7d11f8f2): adds e2e-kind, bench-kind-compare, bench-kwok-compare targets.
  - Build scripts hardened for CI/local use: [build/build-base.sh](https://github.com/pacoxu/kubebrain/pull/1/files#diff-5ed5ba2435f245f2db1918982f5f9547e75658ad7f4f8e0f4f9f08c6bdca93eb), [build/build-badger.sh](https://github.com/pacoxu/kubebrain/pull/1/files#diff-6dfb99195fa0f0f082e9f5243ab319da6d6f0f9f2db24b72777fbc0c6dce86fb), [build/build-tikv.sh](https://github.com/pacoxu/kubebrain/pull/1/files#diff-c0c08eff3e04f4f16e747246d76a29213bd80f4c54df7b3f30c949db2f10f3f4).

#### Which issue(s) this PR fixes:

#### Special notes for your reviewer:
