### PR TITLE
test: add kind e2e TiKV pod persistence checks

### DIFF
--- a/makefile
+++ b/makefile
@@ -16,6 +16,10 @@ test-coverage:
 e2e-kind:
 	bash ./test/e2e/kind/run.sh
 
+.PHONY: e2e-kind-tikv
+e2e-kind-tikv:
+	BUILD_TARGET=tikv bash ./test/e2e/kind/run.sh
+
 .PHONY: bench-kind-compare
 bench-kind-compare:
 	bash ./test/benchmark/kind/compare.sh

--- a/test/e2e/kind/run.sh
+++ b/test/e2e/kind/run.sh
@@ -18,11 +18,23 @@ KUBEBRAIN_PEER_PORT="${KUBEBRAIN_PEER_PORT:-3380}"
 KUBEBRAIN_INFO_PORT="${KUBEBRAIN_INFO_PORT:-3381}"
 
 E2E_NAMESPACE="${E2E_NAMESPACE:-kb-e2e}"
+E2E_POD_NAME="${E2E_POD_NAME:-pod-e2e}"
+E2E_POD_IMAGE="${E2E_POD_IMAGE:-registry.k8s.io/pause:3.10}"
 KEEP_CLUSTER="${KEEP_CLUSTER:-false}"
 SKIP_BUILD="${SKIP_BUILD:-false}"
 KUBEBRAIN_KEY_PREFIX="${KUBEBRAIN_KEY_PREFIX:-}"
 
+TIKV_PD_ADDRS="${TIKV_PD_ADDRS:-}"
+TIKV_PD_IMAGE="${TIKV_PD_IMAGE:-pingcap/pd:v6.5.7}"
+TIKV_KV_IMAGE="${TIKV_KV_IMAGE:-pingcap/tikv:v6.5.7}"
+TIKV_PD_CONTAINER="${TIKV_PD_CONTAINER:-${CLUSTER_NAME}-pd}"
+TIKV_KV_CONTAINER="${TIKV_KV_CONTAINER:-${CLUSTER_NAME}-tikv}"
+TIKV_BOOTSTRAP_WAIT_SECONDS="${TIKV_BOOTSTRAP_WAIT_SECONDS:-25}"
+TIKV_CHECK_TIMEOUT_SECONDS="${TIKV_CHECK_TIMEOUT_SECONDS:-90}"
+
 CONTROL_PLANE_NODE=""
+KIND_NETWORK=""
+STARTED_LOCAL_TIKV="false"
 
 log() {
   printf '[kind-e2e] %s\n' "$*"
@@ -35,6 +47,24 @@ require_cmd() {
   fi
 }
 
+detect_node_arch() {
+  local node="$1"
+  local node_arch_raw
+  node_arch_raw="$(docker exec "${node}" uname -m | tr -d '\r\n')"
+  case "${node_arch_raw}" in
+  aarch64 | arm64)
+    echo "arm64"
+    ;;
+  x86_64 | amd64)
+    echo "amd64"
+    ;;
+  *)
+    echo "unsupported node architecture: ${node_arch_raw}" >&2
+    return 1
+    ;;
+  esac
+}
+
 dump_debug() {
   log "dumping debug info"
   kubectl --context "${KIND_CONTEXT}" get nodes -o wide || true
@@ -42,9 +72,27 @@ dump_debug() {
   if [[ -n "${CONTROL_PLANE_NODE}" ]]; then
     docker exec "${CONTROL_PLANE_NODE}" sh -lc "if [ -f /var/log/kubebrain.log ]; then tail -n 200 /var/log/kubebrain.log; else echo 'kubebrain log file not found'; fi" || true
   fi
+  if [[ "${BUILD_TARGET}" == "tikv" ]]; then
+    if docker inspect "${TIKV_PD_CONTAINER}" >/dev/null 2>&1; then
+      docker logs --tail 200 "${TIKV_PD_CONTAINER}" || true
+    fi
+    if docker inspect "${TIKV_KV_CONTAINER}" >/dev/null 2>&1; then
+      docker logs --tail 200 "${TIKV_KV_CONTAINER}" || true
+    fi
+  fi
+}
+
+cleanup_local_tikv() {
+  if [[ "${STARTED_LOCAL_TIKV}" != "true" ]]; then
+    return
+  fi
+  log "deleting local TiKV containers"
+  docker rm -f "${TIKV_KV_CONTAINER}" >/dev/null 2>&1 || true
+  docker rm -f "${TIKV_PD_CONTAINER}" >/dev/null 2>&1 || true
 }
 
 cleanup() {
+  cleanup_local_tikv
   if [[ "${KEEP_CLUSTER}" == "true" ]]; then
     log "KEEP_CLUSTER=true, skip deleting kind cluster ${CLUSTER_NAME}"
     return
@@ -53,12 +101,87 @@ cleanup() {
   kind delete cluster --name "${CLUSTER_NAME}" >/dev/null 2>&1 || true
 }
 
+start_local_tikv() {
+  if [[ -n "${TIKV_PD_ADDRS}" ]]; then
+    log "using external TiKV PD addresses: ${TIKV_PD_ADDRS}"
+    return
+  fi
+  if [[ -z "${KIND_NETWORK}" ]]; then
+    echo "failed to detect docker network for kind cluster ${CLUSTER_NAME}" >&2
+    exit 1
+  fi
+
+  log "starting local TiKV (pd + tikv) on docker network ${KIND_NETWORK}"
+  docker rm -f "${TIKV_KV_CONTAINER}" >/dev/null 2>&1 || true
+  docker rm -f "${TIKV_PD_CONTAINER}" >/dev/null 2>&1 || true
+
+  docker run -d \
+    --name "${TIKV_PD_CONTAINER}" \
+    --network "${KIND_NETWORK}" \
+    "${TIKV_PD_IMAGE}" \
+    /pd-server \
+    --name=pd-e2e \
+    --data-dir=/var/lib/pd \
+    --client-urls=http://0.0.0.0:2379 \
+    --advertise-client-urls="http://${TIKV_PD_CONTAINER}:2379" \
+    --peer-urls=http://0.0.0.0:2380 \
+    --advertise-peer-urls="http://${TIKV_PD_CONTAINER}:2380" \
+    --initial-cluster="pd-e2e=http://${TIKV_PD_CONTAINER}:2380" \
+    --initial-cluster-state=new >/dev/null
+
+  docker run -d \
+    --name "${TIKV_KV_CONTAINER}" \
+    --network "${KIND_NETWORK}" \
+    "${TIKV_KV_IMAGE}" \
+    /tikv-server \
+    --pd="http://${TIKV_PD_CONTAINER}:2379" \
+    --addr="0.0.0.0:20160" \
+    --advertise-addr="${TIKV_KV_CONTAINER}:20160" \
+    --status-addr="0.0.0.0:20180" \
+    --data-dir=/var/lib/tikv >/dev/null
+
+  STARTED_LOCAL_TIKV="true"
+  TIKV_PD_ADDRS="${TIKV_PD_CONTAINER}:2379"
+  log "waiting ${TIKV_BOOTSTRAP_WAIT_SECONDS}s for TiKV bootstrap"
+  sleep "${TIKV_BOOTSTRAP_WAIT_SECONDS}"
+}
+
+run_tikv_pod_spec_check() {
+  local checker_bin
+  checker_bin="$(mktemp "${TMPDIR:-/tmp}/kb-tikv-check.XXXXXX")"
+
+  log "building TiKV verification helper"
+  GOOS=linux GOARCH="${KUBEBRAIN_GOARCH}" CGO_ENABLED=0 go build -tags tikv -o "${checker_bin}" ./test/e2e/kind/tikvcheck
+  docker cp "${checker_bin}" "${CONTROL_PLANE_NODE}:/usr/local/bin/kb-tikv-check"
+  rm -f "${checker_bin}"
+
+  log "verifying pod spec directly from TiKV"
+  docker exec "${CONTROL_PLANE_NODE}" /usr/local/bin/kb-tikv-check \
+    --pd-addrs="${TIKV_PD_ADDRS}" \
+    --namespace="${E2E_NAMESPACE}" \
+    --pod-name="${E2E_POD_NAME}" \
+    --expected-image="${E2E_POD_IMAGE}" \
+    --key-prefix="${KUBEBRAIN_KEY_PREFIX}" \
+    --timeout="${TIKV_CHECK_TIMEOUT_SECONDS}s"
+}
+
 trap 'rc=$?; if [[ $rc -ne 0 ]]; then dump_debug; fi; cleanup; exit $rc' EXIT
 
 require_cmd kind
 require_cmd kubectl
 require_cmd docker
 require_cmd make
+if [[ "${BUILD_TARGET}" == "tikv" ]]; then
+  require_cmd go
+fi
+
+case "${BUILD_TARGET}" in
+badger | tikv) ;;
+*)
+  echo "unsupported BUILD_TARGET=${BUILD_TARGET}; expected badger or tikv" >&2
+  exit 1
+  ;;
+esac
 
 if [[ -n "${KUBEBRAIN_KEY_PREFIX}" && "${KUBEBRAIN_KEY_PREFIX}" == */ ]]; then
   echo "invalid KUBEBRAIN_KEY_PREFIX=${KUBEBRAIN_KEY_PREFIX}: trailing '/' is not allowed" >&2
@@ -84,22 +207,21 @@ if [[ -z "${CONTROL_PLANE_NODE}" ]]; then
   exit 1
 fi
 
+KIND_NETWORK="$(docker inspect "${CONTROL_PLANE_NODE}" --format '{{range $k, $v := .NetworkSettings.Networks}}{{println $k}}{{end}}' | head -n1 | tr -d '\r\n')"
+if [[ -z "${KIND_NETWORK}" ]]; then
+  echo "failed to detect kind docker network" >&2
+  exit 1
+fi
+
+if [[ -z "${KUBEBRAIN_GOARCH}" ]]; then
+  KUBEBRAIN_GOARCH="$(detect_node_arch "${CONTROL_PLANE_NODE}")"
+fi
+
+if [[ "${BUILD_TARGET}" == "tikv" ]]; then
+  start_local_tikv
+fi
+
 if [[ "${SKIP_BUILD}" != "true" ]]; then
-  if [[ -z "${KUBEBRAIN_GOARCH}" ]]; then
-    node_arch_raw="$(docker exec "${CONTROL_PLANE_NODE}" uname -m | tr -d '\r\n')"
-    case "${node_arch_raw}" in
-    aarch64 | arm64)
-      KUBEBRAIN_GOARCH="arm64"
-      ;;
-    x86_64 | amd64)
-      KUBEBRAIN_GOARCH="amd64"
-      ;;
-    *)
-      echo "unsupported node architecture: ${node_arch_raw}" >&2
-      exit 1
-      ;;
-    esac
-  fi
   log "building kube-brain binary using make ${BUILD_TARGET}"
   log "build target platform: GOOS=${KUBEBRAIN_GOOS} GOARCH=${KUBEBRAIN_GOARCH} CGO_ENABLED=${KUBEBRAIN_CGO_ENABLED}"
   GOOS="${KUBEBRAIN_GOOS}" GOARCH="${KUBEBRAIN_GOARCH}" CGO_ENABLED="${KUBEBRAIN_CGO_ENABLED}" make "${BUILD_TARGET}"
@@ -113,6 +235,15 @@ fi
 log "copying kube-brain binary to ${CONTROL_PLANE_NODE}"
 docker cp ./bin/kube-brain "${CONTROL_PLANE_NODE}:/usr/local/bin/kube-brain"
 
+kubebrain_storage_flags="--data-dir=/var/lib/kubebrain"
+if [[ "${BUILD_TARGET}" == "tikv" ]]; then
+  if [[ -z "${TIKV_PD_ADDRS}" ]]; then
+    echo "TiKV backend selected but TIKV_PD_ADDRS is empty" >&2
+    exit 1
+  fi
+  kubebrain_storage_flags="--pd-addrs=${TIKV_PD_ADDRS}"
+fi
+
 log "starting kube-brain inside kind node"
 docker exec "${CONTROL_PLANE_NODE}" sh -lc "
 set -eu
@@ -121,7 +252,7 @@ if pgrep -x kube-brain >/dev/null 2>&1; then
   pkill -x kube-brain || true
 fi
 nohup /usr/local/bin/kube-brain \
-  --data-dir=/var/lib/kubebrain \
+  ${kubebrain_storage_flags} \
   --key-prefix='${KUBEBRAIN_KEY_PREFIX}' \
   --compatible-with-etcd=true \
   --port=${KUBEBRAIN_PORT} \
@@ -189,6 +320,48 @@ if ! grep -q 'cm-watch' "${watch_log}"; then
   exit 1
 fi
 rm -f "${watch_log}"
+
+log "running Pod create/running smoke test"
+kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" delete pod "${E2E_POD_NAME}" --ignore-not-found=true --wait=true
+cat <<EOF | kubectl --context "${KIND_CONTEXT}" apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: ${E2E_POD_NAME}
+  namespace: ${E2E_NAMESPACE}
+spec:
+  tolerations:
+  - key: "node-role.kubernetes.io/control-plane"
+    operator: "Exists"
+    effect: "NoSchedule"
+  - key: "node-role.kubernetes.io/master"
+    operator: "Exists"
+    effect: "NoSchedule"
+  containers:
+  - name: pause
+    image: ${E2E_POD_IMAGE}
+EOF
+
+pod_phase=""
+for _ in $(seq 1 120); do
+  pod_phase="$(kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" get pod "${E2E_POD_NAME}" -o jsonpath='{.status.phase}' 2>/dev/null || true)"
+  if [[ "${pod_phase}" == "Running" ]]; then
+    break
+  fi
+  if [[ "${pod_phase}" == "Failed" ]]; then
+    break
+  fi
+  sleep 2
+done
+if [[ "${pod_phase}" != "Running" ]]; then
+  echo "pod ${E2E_POD_NAME} did not reach Running, current phase=${pod_phase}" >&2
+  kubectl --context "${KIND_CONTEXT}" -n "${E2E_NAMESPACE}" describe pod "${E2E_POD_NAME}" >&2 || true
+  exit 1
+fi
+
+if [[ "${BUILD_TARGET}" == "tikv" ]]; then
+  run_tikv_pod_spec_check
+fi
 
 log "validating kube-brain log for severe errors"
 docker exec "${CONTROL_PLANE_NODE}" sh -lc "grep -E 'panic|fatal' /var/log/kubebrain.log && exit 1 || true"

--- a/test/e2e/kind/tikvcheck/main.go
+++ b/test/e2e/kind/tikvcheck/main.go
@@ -1,0 +1,237 @@
+// Copyright 2022 ByteDance and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	tikverr "github.com/tikv/client-go/v2/error"
+	"github.com/tikv/client-go/v2/txnkv"
+)
+
+var (
+	magicBytes = []byte{0x57, 0xfb, 0x80, 0x8b}
+	splitByte  = byte('$')
+)
+
+type options struct {
+	pdAddrs       string
+	namespace     string
+	podName       string
+	expectedImage string
+	keyPrefix     string
+	timeout       time.Duration
+	retryInterval time.Duration
+}
+
+func parseFlags() (*options, error) {
+	opt := &options{}
+	flag.StringVar(&opt.pdAddrs, "pd-addrs", "", "comma-separated PD addresses")
+	flag.StringVar(&opt.namespace, "namespace", "", "pod namespace")
+	flag.StringVar(&opt.podName, "pod-name", "", "pod name")
+	flag.StringVar(&opt.expectedImage, "expected-image", "", "expected pod image in stored value")
+	flag.StringVar(&opt.keyPrefix, "key-prefix", "", "optional key prefix used by kube-brain")
+	flag.DurationVar(&opt.timeout, "timeout", 90*time.Second, "max time to wait for Pod object in TiKV")
+	flag.DurationVar(&opt.retryInterval, "retry-interval", time.Second, "retry interval when key is not ready")
+	flag.Parse()
+
+	if strings.TrimSpace(opt.pdAddrs) == "" {
+		return nil, errors.New("missing --pd-addrs")
+	}
+	if strings.TrimSpace(opt.namespace) == "" {
+		return nil, errors.New("missing --namespace")
+	}
+	if strings.TrimSpace(opt.podName) == "" {
+		return nil, errors.New("missing --pod-name")
+	}
+	if opt.timeout <= 0 {
+		return nil, fmt.Errorf("invalid --timeout=%s", opt.timeout)
+	}
+	if opt.retryInterval <= 0 {
+		return nil, fmt.Errorf("invalid --retry-interval=%s", opt.retryInterval)
+	}
+	return opt, nil
+}
+
+func splitPDAddrs(input string) []string {
+	parts := strings.Split(input, ",")
+	result := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		result = append(result, p)
+	}
+	return result
+}
+
+func encodeObjectKey(userKey []byte, revision uint64) []byte {
+	key := make([]byte, len(magicBytes)+len(userKey)+1+8)
+	copy(key, magicBytes)
+	copy(key[len(magicBytes):], userKey)
+	key[len(magicBytes)+len(userKey)] = splitByte
+	binary.BigEndian.PutUint64(key[len(magicBytes)+len(userKey)+1:], revision)
+	return key
+}
+
+func buildRawKeyCandidates(prefix string, namespace string, podName string) []string {
+	base := path.Join("/registry/pods", namespace, podName)
+	candidates := []string{base}
+
+	normalized := strings.TrimSpace(prefix)
+	if normalized != "" && normalized != "/" {
+		if !strings.HasPrefix(normalized, "/") {
+			normalized = "/" + normalized
+		}
+		normalized = strings.TrimSuffix(normalized, "/")
+		candidates = append(candidates, path.Join(normalized, "registry", "pods", namespace, podName))
+	}
+
+	uniq := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, key := range candidates {
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		uniq = append(uniq, key)
+	}
+	return uniq
+}
+
+func readValue(ctx context.Context, client *txnkv.Client, key []byte) ([]byte, error) {
+	ts, err := client.GetTimestamp(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("get timestamp: %w", err)
+	}
+	snapshot := client.GetSnapshot(ts)
+	value, err := snapshot.Get(ctx, key)
+	if err != nil {
+		if tikverr.IsErrNotFound(err) {
+			return nil, err
+		}
+		return nil, fmt.Errorf("snapshot get key %x: %w", key, err)
+	}
+	return value, nil
+}
+
+func verifyRawPodKey(ctx context.Context, client *txnkv.Client, rawKey string, expectedImage string) error {
+	revisionKey := encodeObjectKey([]byte(rawKey), 0)
+	revisionValue, err := readValue(ctx, client, revisionKey)
+	if err != nil {
+		if tikverr.IsErrNotFound(err) {
+			return fmt.Errorf("revision key not found for raw key %q", rawKey)
+		}
+		return err
+	}
+	if len(revisionValue) < 8 {
+		return fmt.Errorf("invalid revision value length=%d for raw key %q", len(revisionValue), rawKey)
+	}
+	if len(revisionValue) == 9 {
+		return fmt.Errorf("raw key %q is tombstoned at revision=%d", rawKey, binary.BigEndian.Uint64(revisionValue[:8]))
+	}
+	if len(revisionValue) != 8 {
+		return fmt.Errorf("unexpected revision value length=%d for raw key %q", len(revisionValue), rawKey)
+	}
+
+	revision := binary.BigEndian.Uint64(revisionValue[:8])
+	objectKey := encodeObjectKey([]byte(rawKey), revision)
+	objectValue, err := readValue(ctx, client, objectKey)
+	if err != nil {
+		if tikverr.IsErrNotFound(err) {
+			return fmt.Errorf("object key not found for raw key %q at revision=%d", rawKey, revision)
+		}
+		return err
+	}
+
+	if len(objectValue) == 0 {
+		return fmt.Errorf("empty object value for raw key %q at revision=%d", rawKey, revision)
+	}
+	if expectedImage != "" && !bytes.Contains(objectValue, []byte(expectedImage)) {
+		return fmt.Errorf("object value for raw key %q does not contain expected image %q", rawKey, expectedImage)
+	}
+
+	parts := strings.Split(strings.Trim(rawKey, "/"), "/")
+	if len(parts) < 2 {
+		return fmt.Errorf("invalid raw key %q", rawKey)
+	}
+	ns := parts[len(parts)-2]
+	name := parts[len(parts)-1]
+	if !bytes.Contains(objectValue, []byte(ns)) {
+		return fmt.Errorf("object value for raw key %q does not contain namespace %q", rawKey, ns)
+	}
+	if !bytes.Contains(objectValue, []byte(name)) {
+		return fmt.Errorf("object value for raw key %q does not contain pod name %q", rawKey, name)
+	}
+
+	fmt.Printf("verified pod key in TiKV: rawKey=%s revision=%d size=%d\n", rawKey, revision, len(objectValue))
+	return nil
+}
+
+func run(opt *options) error {
+	pdAddrs := splitPDAddrs(opt.pdAddrs)
+	if len(pdAddrs) == 0 {
+		return errors.New("no valid PD addresses from --pd-addrs")
+	}
+
+	client, err := txnkv.NewClient(pdAddrs)
+	if err != nil {
+		return fmt.Errorf("create TiKV client: %w", err)
+	}
+	defer func() { _ = client.Close() }()
+
+	keys := buildRawKeyCandidates(opt.keyPrefix, opt.namespace, opt.podName)
+	deadline := time.Now().Add(opt.timeout)
+	var lastErr error
+	for {
+		for _, rawKey := range keys {
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			err := verifyRawPodKey(ctx, client, rawKey, opt.expectedImage)
+			cancel()
+			if err == nil {
+				return nil
+			}
+			lastErr = err
+		}
+
+		if time.Now().After(deadline) {
+			break
+		}
+		time.Sleep(opt.retryInterval)
+	}
+	return fmt.Errorf("failed to verify pod key from TiKV after %s: %w", opt.timeout, lastErr)
+}
+
+func main() {
+	opt, err := parseFlags()
+	if err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "invalid flags: %v\n", err)
+		os.Exit(1)
+	}
+	if err := run(opt); err != nil {
+		_, _ = fmt.Fprintf(os.Stderr, "tikv pod verification failed: %v\n", err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
## Summary
- extend test/e2e/kind/run.sh to support badger and tikv backends in one flow
- add pod scheduling smoke coverage (create pod and verify it reaches Running)
- for TiKV mode, verify pod object persistence by reading TiKV directly via a new checker helper
- add make e2e-kind-tikv target

## Validation
- bash -n test/e2e/kind/run.sh
- go test ./test/e2e/kind/tikvcheck
- make -n e2e-kind-tikv
