### PR TITLE
docs: link TODO items to tracking issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ We investigated some of existing distributed storage systems, and analyzed the p
 - [Benchmark](./docs/benchmark.md)
 
 ## TODO
-- [ ] Guarantee consistence in critical cases
-- [ ] Optimize storage engine interface
-- [ ] Optimize unit test code, add use cases and error injection
-- [ ] [Jepsen Test](https://jepsen.io/)
-- [ ] Implement Proxy to make it more scalable
+- [ ] [Guarantee consistence in critical cases](https://github.com/pacoxu/kubebrain/issues/3)
+- [ ] [Optimize storage engine interface](https://github.com/pacoxu/kubebrain/issues/4)
+- [ ] [Optimize unit test code, add use cases and error injection](https://github.com/pacoxu/kubebrain/issues/5)
+- [ ] [Jepsen Test](https://github.com/pacoxu/kubebrain/issues/6)
+- [ ] [Implement Proxy to make it more scalable](https://github.com/pacoxu/kubebrain/issues/7)
 
 
 ## Contribution
@@ -51,4 +51,3 @@ Please check [Code of Conduct](CODE_OF_CONDUCT.md) for more details.
 ## License
 
 This project is licensed under the [Apache-2.0 License](LICENSE).
-

--- a/README_CN.md
+++ b/README_CN.md
@@ -34,12 +34,12 @@
 
 # TODO
 
-- [ ] 优化存储引擎接口
-- [ ] 极端情况下的一致性保证
+- [ ] [优化存储引擎接口](https://github.com/pacoxu/kubebrain/issues/4)
+- [ ] [极端情况下的一致性保证](https://github.com/pacoxu/kubebrain/issues/3)
 - [ ] 内置的逻辑时钟
-- [ ] 优化单元测试代码，增加用例和错误注入
-- [ ] [Jepsen测试](https://jepsen.io/)
-- [ ] 实现Proxy功能
+- [ ] [优化单元测试代码，增加用例和错误注入](https://github.com/pacoxu/kubebrain/issues/5)
+- [ ] [Jepsen测试](https://github.com/pacoxu/kubebrain/issues/6)
+- [ ] [实现Proxy功能](https://github.com/pacoxu/kubebrain/issues/7)
 
 # 贡献代码
 


### PR DESCRIPTION
## Summary
- create and link tracking issues for the 5 TODO items in README.md
- mirror the same issue links for corresponding TODO items in README_CN.md
- keep non-requested TODO item (内置的逻辑时钟) unchanged

## Tracking Issues
- #3 Guarantee consistency in critical cases
- #4 Optimize storage engine interface
- #5 Optimize unit test code, add use cases and error injection
- #6 Jepsen Test
- #7 Implement Proxy to make it more scalable

## Validation
- verified both README TODO sections contain the expected issue links
