### PR TITLE
test: add initial Jepsen harness and checker

### DIFF
--- a/makefile
+++ b/makefile
@@ -23,3 +23,7 @@ bench-kind-compare:
 .PHONY: bench-kwok-compare
 bench-kwok-compare:
 	bash ./test/benchmark/kwok/compare.sh
+
+.PHONY: jepsen
+jepsen:
+	bash ./test/jepsen/run.sh

--- a/test/jepsen/README.md
+++ b/test/jepsen/README.md
@@ -1,0 +1,90 @@
+# Jepsen Test Harness (Issue #6)
+
+This directory contains the first-stage Jepsen-style test harness for KubeBrain.
+
+It provides:
+- a concurrent workload generator that writes operation history to JSONL;
+- a machine-checkable invariant checker;
+- a reproducible shell entrypoint with optional fault-command hooks.
+
+## Scope
+
+This harness validates critical invariants from operation history:
+- global response revision monotonicity;
+- per-key write revision strict increase;
+- no phantom resurrection after delete (with overlap-aware checks).
+
+It does **not** implement full formal linearizability checking yet. That is planned as a follow-up.
+
+## Layout
+
+- `harness/main.go`: workload runner.
+- `checker/main.go`: invariant checker.
+- `history/history.go`: shared record model and JSONL loader.
+- `run.sh`: end-to-end runner.
+- `artifacts/`: default output directory.
+
+## Quick Start
+
+Run against a reachable KubeBrain endpoint:
+
+```bash
+./test/jepsen/run.sh
+```
+
+Useful overrides:
+
+```bash
+ENDPOINTS=10.0.0.10:2379 \
+DURATION=3m \
+WORKERS=32 \
+KEYS=128 \
+./test/jepsen/run.sh
+```
+
+Dry run with fixed operation count:
+
+```bash
+OPS_PER_WORKER=200 WORKERS=8 ./test/jepsen/run.sh
+```
+
+## Fault Injection Hook
+
+You can provide a fault command that runs periodically while workload is running:
+
+```bash
+FAULT_CMD='kubectl -n kube-system delete pod -l app=kubebrain --wait=false' \
+FAULT_INTERVAL_SEC=60 \
+./test/jepsen/run.sh
+```
+
+The harness does not hardcode cluster fault logic. It executes `FAULT_CMD` as-is.
+
+## Artifacts
+
+Default outputs:
+- `test/jepsen/artifacts/history.jsonl`
+- `test/jepsen/artifacts/report.json`
+
+Checker exits non-zero when any invariant fails.
+
+## Manual Commands
+
+Run workload only:
+
+```bash
+go run ./test/jepsen/harness -endpoints 127.0.0.1:2379 -duration 2m -out test/jepsen/artifacts/history.jsonl
+```
+
+Run checker only:
+
+```bash
+go run ./test/jepsen/checker -history test/jepsen/artifacts/history.jsonl -report test/jepsen/artifacts/report.json
+```
+
+## Next Steps
+
+- Add richer fault scenario scripts (partition, latency, restart matrix).
+- Integrate a full linearizability checker pipeline.
+- Add CI gating job for deterministic short Jepsen runs.
+

--- a/test/jepsen/artifacts/.gitignore
+++ b/test/jepsen/artifacts/.gitignore
@@ -1,0 +1,3 @@
+*
+!.gitignore
+

--- a/test/jepsen/checker/main.go
+++ b/test/jepsen/checker/main.go
@@ -1,0 +1,260 @@
+// Copyright 2022 ByteDance and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kubewharf/kubebrain/test/jepsen/history"
+)
+
+type violation struct {
+	Invariant string `json:"invariant"`
+	RecordID  int64  `json:"record_id"`
+	Key       string `json:"key,omitempty"`
+	Detail    string `json:"detail"`
+}
+
+type invariantResult struct {
+	Name       string      `json:"name"`
+	Passed     bool        `json:"passed"`
+	Violations []violation `json:"violations,omitempty"`
+}
+
+type report struct {
+	GeneratedAtUTC        string                 `json:"generated_at_utc"`
+	HistoryPath           string                 `json:"history_path"`
+	TotalRecords          int                    `json:"total_records"`
+	SuccessfulRecords     int                    `json:"successful_records"`
+	TransportErrorRecords int                    `json:"transport_error_records"`
+	ByOperation           map[string]int         `json:"by_operation"`
+	MaxResponseRevision   int64                  `json:"max_response_revision"`
+	Invariants            []invariantResult      `json:"invariants"`
+	Passed                bool                   `json:"passed"`
+	Summary               map[string]interface{} `json:"summary"`
+}
+
+func main() {
+	var (
+		historyPath = flag.String("history", "test/jepsen/artifacts/history.jsonl", "history JSONL path")
+		reportPath  = flag.String("report", "test/jepsen/artifacts/report.json", "checker report path")
+	)
+	flag.Parse()
+
+	records, err := history.LoadJSONL(*historyPath)
+	if err != nil {
+		exitf("load history failed: %v", err)
+	}
+	if len(records) == 0 {
+		exitf("history is empty: %s", *historyPath)
+	}
+
+	history.SortByFinish(records)
+
+	rep := buildBaseReport(*historyPath, records)
+	invariants := make([]invariantResult, 0, 3)
+
+	invariants = append(invariants, evaluate("global_response_revision_monotonic", checkGlobalRevisionMonotonic(records)))
+	invariants = append(invariants, evaluate("per_key_write_revision_strictly_increasing", checkPerKeyWriteRevision(records)))
+	invariants = append(invariants, evaluate("no_phantom_resurrection_after_delete", checkNoPhantomResurrection(records)))
+
+	rep.Invariants = invariants
+	rep.Passed = true
+	for _, inv := range invariants {
+		if !inv.Passed {
+			rep.Passed = false
+			break
+		}
+	}
+
+	rep.Summary = map[string]interface{}{
+		"note": "This checker validates Jepsen-style invariants from operation history; full linearizability checking is out of scope for this first-stage harness.",
+	}
+
+	if err := os.MkdirAll(filepath.Dir(*reportPath), 0755); err != nil {
+		exitf("create report directory failed: %v", err)
+	}
+	if err := writeReport(*reportPath, rep); err != nil {
+		exitf("write report failed: %v", err)
+	}
+
+	fmt.Printf("checker report written to %s (passed=%v)\n", *reportPath, rep.Passed)
+	if !rep.Passed {
+		os.Exit(1)
+	}
+}
+
+func buildBaseReport(historyPath string, records []history.Record) report {
+	byOp := make(map[string]int)
+	success := 0
+	transportErr := 0
+	maxRevision := int64(0)
+
+	for _, r := range records {
+		byOp[string(r.Operation)]++
+		if r.Succeeded {
+			success++
+		}
+		if r.TransportError != "" {
+			transportErr++
+		}
+		if r.ResponseRevision > maxRevision {
+			maxRevision = r.ResponseRevision
+		}
+	}
+
+	return report{
+		GeneratedAtUTC:        time.Now().UTC().Format(time.RFC3339),
+		HistoryPath:           historyPath,
+		TotalRecords:          len(records),
+		SuccessfulRecords:     success,
+		TransportErrorRecords: transportErr,
+		ByOperation:           byOp,
+		MaxResponseRevision:   maxRevision,
+	}
+}
+
+func evaluate(name string, violations []violation) invariantResult {
+	return invariantResult{
+		Name:       name,
+		Passed:     len(violations) == 0,
+		Violations: violations,
+	}
+}
+
+func checkGlobalRevisionMonotonic(records []history.Record) []violation {
+	prev := int64(-1)
+	violations := make([]violation, 0)
+	for _, r := range records {
+		if !r.Succeeded || r.ResponseRevision <= 0 {
+			continue
+		}
+		if prev > r.ResponseRevision {
+			violations = append(violations, violation{
+				Invariant: "global_response_revision_monotonic",
+				RecordID:  r.ID,
+				Key:       r.Key,
+				Detail:    fmt.Sprintf("response revision decreased from %d to %d", prev, r.ResponseRevision),
+			})
+		}
+		if r.ResponseRevision > prev {
+			prev = r.ResponseRevision
+		}
+	}
+	return violations
+}
+
+func checkPerKeyWriteRevision(records []history.Record) []violation {
+	lastWriteRevision := make(map[string]int64)
+	violations := make([]violation, 0)
+
+	for _, r := range records {
+		if !r.Succeeded {
+			continue
+		}
+		if r.Operation != history.OpCreate && r.Operation != history.OpUpdate && r.Operation != history.OpDelete {
+			continue
+		}
+		if r.Key == "" || r.ResponseRevision <= 0 {
+			continue
+		}
+		prev := lastWriteRevision[r.Key]
+		if prev >= r.ResponseRevision {
+			violations = append(violations, violation{
+				Invariant: "per_key_write_revision_strictly_increasing",
+				RecordID:  r.ID,
+				Key:       r.Key,
+				Detail:    fmt.Sprintf("write revision is not strictly increasing: previous=%d current=%d", prev, r.ResponseRevision),
+			})
+		}
+		if r.ResponseRevision > prev {
+			lastWriteRevision[r.Key] = r.ResponseRevision
+		}
+	}
+	return violations
+}
+
+type deletionState struct {
+	revision   int64
+	finishNano int64
+}
+
+func checkNoPhantomResurrection(records []history.Record) []violation {
+	lastDelete := make(map[string]deletionState)
+	violations := make([]violation, 0)
+
+	for _, r := range records {
+		if !r.Succeeded {
+			continue
+		}
+
+		switch r.Operation {
+		case history.OpDelete:
+			if r.Key != "" && r.ResponseRevision > 0 {
+				lastDelete[r.Key] = deletionState{
+					revision:   r.ResponseRevision,
+					finishNano: r.FinishUnixNano,
+				}
+			}
+		case history.OpCreate, history.OpUpdate:
+			if r.Key != "" {
+				delete(lastDelete, r.Key)
+			}
+		case history.OpGet:
+			if !r.KeyFound || r.Key == "" || r.ResponseModRevision <= 0 {
+				continue
+			}
+			del, ok := lastDelete[r.Key]
+			if !ok {
+				continue
+			}
+			// Ignore overlapping operations where GET invocation started before delete finished.
+			if r.InvokeUnixNano <= del.finishNano {
+				continue
+			}
+			if r.ResponseModRevision <= del.revision {
+				violations = append(violations, violation{
+					Invariant: "no_phantom_resurrection_after_delete",
+					RecordID:  r.ID,
+					Key:       r.Key,
+					Detail:    fmt.Sprintf("get observed mod_revision=%d after delete revision=%d", r.ResponseModRevision, del.revision),
+				})
+			}
+		}
+	}
+	return violations
+}
+
+func writeReport(path string, r report) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	enc := json.NewEncoder(file)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+func exitf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/test/jepsen/harness/main.go
+++ b/test/jepsen/harness/main.go
@@ -1,0 +1,451 @@
+// Copyright 2022 ByteDance and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	proto "github.com/kubewharf/kubebrain-client/api/v2rpc"
+	"go.etcd.io/etcd/client/v3"
+	"google.golang.org/grpc"
+
+	"github.com/kubewharf/kubebrain/test/jepsen/history"
+)
+
+func main() {
+	var (
+		endpointsArg       = flag.String("endpoints", "127.0.0.1:2379", "comma-separated etcd/kubebrain endpoints")
+		duration           = flag.Duration("duration", 2*time.Minute, "workload duration")
+		workers            = flag.Int("workers", 16, "number of concurrent workers")
+		keys               = flag.Int("keys", 64, "number of keys in keyspace")
+		keyPrefix          = flag.String("key-prefix", "/jepsen/kubebrain/", "key prefix for workload")
+		timeout            = flag.Duration("timeout", 3*time.Second, "per-operation timeout")
+		outPath            = flag.String("out", "test/jepsen/artifacts/history.jsonl", "history output JSONL path")
+		seed               = flag.Int64("seed", 0, "random seed, 0 means auto")
+		opsPerWorker       = flag.Int("ops-per-worker", 0, "stop each worker after N ops, 0 means unlimited")
+		compactInterval    = flag.Duration("compact-interval", 30*time.Second, "interval for compact requests, 0 disables compact")
+		compactRevisionLag = flag.Uint64("compact-revision-lag", 100, "compact target is max_observed_revision - lag")
+	)
+	flag.Parse()
+
+	if *workers <= 0 {
+		exitf("workers must be greater than 0")
+	}
+	if *keys <= 0 {
+		exitf("keys must be greater than 0")
+	}
+	if *duration <= 0 && *opsPerWorker <= 0 {
+		exitf("duration must be greater than 0 when ops-per-worker is 0")
+	}
+	if *timeout <= 0 {
+		exitf("timeout must be greater than 0")
+	}
+
+	endpoints := splitNonEmpty(*endpointsArg)
+	if len(endpoints) == 0 {
+		exitf("at least one endpoint is required")
+	}
+
+	if *seed == 0 {
+		*seed = time.Now().UnixNano()
+	}
+	fmt.Printf("jepsen harness seed=%d endpoints=%v workers=%d keys=%d\n", *seed, endpoints, *workers, *keys)
+
+	cli, err := clientv3.New(clientv3.Config{
+		Endpoints:   endpoints,
+		DialTimeout: *timeout,
+	})
+	if err != nil {
+		exitf("create etcd client failed: %v", err)
+	}
+	defer cli.Close()
+
+	grpcCtx, grpcCancel := context.WithTimeout(context.Background(), *timeout)
+	conn, err := grpc.DialContext(grpcCtx, endpoints[0], grpc.WithInsecure(), grpc.WithBlock())
+	grpcCancel()
+	if err != nil {
+		exitf("create grpc connection for compact failed: %v", err)
+	}
+	defer conn.Close()
+	writeClient := proto.NewWriteClient(conn)
+
+	if err := os.MkdirAll(filepath.Dir(*outPath), 0755); err != nil {
+		exitf("create output directory failed: %v", err)
+	}
+
+	recordCh := make(chan history.Record, 2048)
+	writeErrCh := make(chan error, 1)
+	go func() {
+		writeErrCh <- writeJSONL(*outPath, recordCh)
+	}()
+
+	var (
+		recordID    int64
+		maxRevision int64
+		workerWG    sync.WaitGroup
+		compactorWG sync.WaitGroup
+		ctx         context.Context
+		cancel      context.CancelFunc
+	)
+
+	if *opsPerWorker > 0 {
+		ctx, cancel = context.WithCancel(context.Background())
+	} else {
+		ctx, cancel = context.WithTimeout(context.Background(), *duration)
+	}
+	defer cancel()
+
+	keyList := make([]string, 0, *keys)
+	for i := 0; i < *keys; i++ {
+		keyList = append(keyList, fmt.Sprintf("%skey-%05d", *keyPrefix, i))
+	}
+
+	start := time.Now()
+	for workerID := 0; workerID < *workers; workerID++ {
+		workerWG.Add(1)
+		go func(workerID int) {
+			defer workerWG.Done()
+			runWorker(ctx, workerID, *seed+int64(workerID)*10007, *timeout, *opsPerWorker, keyList, cli, recordCh, &recordID, &maxRevision)
+		}(workerID)
+	}
+
+	if *compactInterval > 0 {
+		compactorWG.Add(1)
+		go func() {
+			defer compactorWG.Done()
+			runCompactor(ctx, *compactInterval, *timeout, int64(*compactRevisionLag), writeClient, recordCh, &recordID, &maxRevision)
+		}()
+	}
+
+	workerWG.Wait()
+	cancel()
+	compactorWG.Wait()
+	close(recordCh)
+
+	if err := <-writeErrCh; err != nil {
+		exitf("write history failed: %v", err)
+	}
+
+	elapsed := time.Since(start)
+	fmt.Printf("jepsen harness done history=%s elapsed=%s max_revision=%d\n", *outPath, elapsed, atomic.LoadInt64(&maxRevision))
+}
+
+func runWorker(
+	ctx context.Context,
+	workerID int,
+	seed int64,
+	timeout time.Duration,
+	opsLimit int,
+	keys []string,
+	cli *clientv3.Client,
+	out chan<- history.Record,
+	idCounter *int64,
+	maxRevision *int64,
+) {
+	rng := rand.New(rand.NewSource(seed))
+
+	opsDone := 0
+	for {
+		if opsLimit > 0 && opsDone >= opsLimit {
+			return
+		}
+		select {
+		case <-ctx.Done():
+			return
+		default:
+		}
+
+		op := chooseOperation(rng.Intn(100))
+		key := keys[rng.Intn(len(keys))]
+		value := fmt.Sprintf("client-%d-op-%d-%d", workerID, opsDone, time.Now().UnixNano())
+		invoke := time.Now().UnixNano()
+
+		rec := history.Record{
+			ID:             atomic.AddInt64(idCounter, 1),
+			ClientID:       workerID,
+			Operation:      op,
+			Key:            key,
+			RequestValue:   value,
+			InvokeUnixNano: invoke,
+		}
+
+		opCtx, cancel := context.WithTimeout(ctx, timeout)
+		switch op {
+		case history.OpCreate:
+			rec.ExpectedModRevision = 0
+			succeeded, respRev, modRev, err := runCreate(opCtx, cli, key, value)
+			rec.Succeeded = succeeded
+			rec.ResponseRevision = respRev
+			rec.ResponseModRevision = modRev
+			if err != nil {
+				rec.TransportError = err.Error()
+			}
+		case history.OpUpdate:
+			found, _, expectedRev, headerRev, err := readCurrent(opCtx, cli, key)
+			if err != nil {
+				rec.TransportError = err.Error()
+				rec.ResponseRevision = headerRev
+				break
+			}
+			rec.ExpectedModRevision = expectedRev
+			succeeded, respRev, modRev, runErr := runUpdate(opCtx, cli, key, value, expectedRev)
+			rec.Succeeded = succeeded
+			rec.ResponseRevision = respRev
+			rec.ResponseModRevision = modRev
+			if runErr != nil {
+				rec.TransportError = runErr.Error()
+			}
+			if !found && succeeded {
+				rec.Note = "update behaved as create due to missing key"
+			}
+		case history.OpDelete:
+			found, _, expectedRev, headerRev, err := readCurrent(opCtx, cli, key)
+			if err != nil {
+				rec.TransportError = err.Error()
+				rec.ResponseRevision = headerRev
+				break
+			}
+			rec.ExpectedModRevision = expectedRev
+			if !found {
+				rec.Succeeded = false
+				rec.ResponseRevision = headerRev
+				rec.Note = "key missing in pre-read"
+				break
+			}
+			succeeded, respRev, modRev, runErr := runDelete(opCtx, cli, key, expectedRev)
+			rec.Succeeded = succeeded
+			rec.ResponseRevision = respRev
+			rec.ResponseModRevision = modRev
+			if runErr != nil {
+				rec.TransportError = runErr.Error()
+			}
+		case history.OpGet:
+			found, val, modRev, respRev, err := readCurrent(opCtx, cli, key)
+			rec.Succeeded = err == nil
+			rec.KeyFound = found
+			rec.ResponseValue = val
+			rec.ResponseModRevision = modRev
+			rec.ResponseRevision = respRev
+			if err != nil {
+				rec.TransportError = err.Error()
+			}
+		}
+		cancel()
+
+		rec.FinishUnixNano = time.Now().UnixNano()
+		updateMaxRevision(maxRevision, rec.ResponseRevision)
+		out <- rec
+		opsDone++
+	}
+}
+
+func runCompactor(
+	ctx context.Context,
+	interval time.Duration,
+	timeout time.Duration,
+	revisionLag int64,
+	client proto.WriteClient,
+	out chan<- history.Record,
+	idCounter *int64,
+	maxRevision *int64,
+) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+
+		maxRev := atomic.LoadInt64(maxRevision)
+		target := maxRev - revisionLag
+		if target < 0 {
+			target = 0
+		}
+
+		invoke := time.Now().UnixNano()
+		rec := history.Record{
+			ID:              atomic.AddInt64(idCounter, 1),
+			ClientID:        -1,
+			Operation:       history.OpCompact,
+			CompactRevision: target,
+			InvokeUnixNano:  invoke,
+		}
+
+		opCtx, cancel := context.WithTimeout(ctx, timeout)
+		resp, err := client.Compact(opCtx, &proto.CompactRequest{Revision: uint64(target)})
+		cancel()
+		if err != nil {
+			rec.TransportError = err.Error()
+			rec.Succeeded = false
+		} else {
+			rec.Succeeded = true
+			if resp != nil && resp.GetHeader() != nil {
+				rec.ResponseRevision = int64(resp.GetHeader().GetRevision())
+			}
+		}
+		rec.FinishUnixNano = time.Now().UnixNano()
+		updateMaxRevision(maxRevision, rec.ResponseRevision)
+		out <- rec
+	}
+}
+
+func chooseOperation(pick int) history.Operation {
+	switch {
+	case pick < 20:
+		return history.OpCreate
+	case pick < 55:
+		return history.OpUpdate
+	case pick < 75:
+		return history.OpDelete
+	default:
+		return history.OpGet
+	}
+}
+
+func runCreate(ctx context.Context, cli *clientv3.Client, key, value string) (bool, int64, int64, error) {
+	txnResp, err := cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", 0)).
+		Then(clientv3.OpPut(key, value)).
+		Else(clientv3.OpGet(key)).
+		Commit()
+	if err != nil {
+		return false, 0, 0, err
+	}
+	respRev := int64(0)
+	if txnResp.Header != nil {
+		respRev = txnResp.Header.Revision
+	}
+	return txnResp.Succeeded, respRev, extractFailureModRevision(txnResp), nil
+}
+
+func runUpdate(ctx context.Context, cli *clientv3.Client, key, value string, expectedModRevision int64) (bool, int64, int64, error) {
+	txnResp, err := cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", expectedModRevision)).
+		Then(clientv3.OpPut(key, value)).
+		Else(clientv3.OpGet(key)).
+		Commit()
+	if err != nil {
+		return false, 0, 0, err
+	}
+	respRev := int64(0)
+	if txnResp.Header != nil {
+		respRev = txnResp.Header.Revision
+	}
+	return txnResp.Succeeded, respRev, extractFailureModRevision(txnResp), nil
+}
+
+func runDelete(ctx context.Context, cli *clientv3.Client, key string, expectedModRevision int64) (bool, int64, int64, error) {
+	txnResp, err := cli.Txn(ctx).
+		If(clientv3.Compare(clientv3.ModRevision(key), "=", expectedModRevision)).
+		Then(clientv3.OpDelete(key)).
+		Else(clientv3.OpGet(key)).
+		Commit()
+	if err != nil {
+		return false, 0, 0, err
+	}
+	respRev := int64(0)
+	if txnResp.Header != nil {
+		respRev = txnResp.Header.Revision
+	}
+	return txnResp.Succeeded, respRev, extractFailureModRevision(txnResp), nil
+}
+
+func readCurrent(ctx context.Context, cli *clientv3.Client, key string) (found bool, value string, modRevision int64, headerRevision int64, err error) {
+	resp, err := cli.Get(ctx, key)
+	if err != nil {
+		return false, "", 0, 0, err
+	}
+	if resp.Header != nil {
+		headerRevision = resp.Header.Revision
+	}
+	if len(resp.Kvs) == 0 {
+		return false, "", 0, headerRevision, nil
+	}
+	kv := resp.Kvs[0]
+	return true, string(kv.Value), kv.ModRevision, headerRevision, nil
+}
+
+func extractFailureModRevision(resp *clientv3.TxnResponse) int64 {
+	if resp == nil || resp.Succeeded || len(resp.Responses) == 0 {
+		return 0
+	}
+	rng := resp.Responses[0].GetResponseRange()
+	if rng == nil || len(rng.Kvs) == 0 {
+		return 0
+	}
+	return rng.Kvs[0].ModRevision
+}
+
+func updateMaxRevision(ptr *int64, value int64) {
+	for {
+		old := atomic.LoadInt64(ptr)
+		if value <= old {
+			return
+		}
+		if atomic.CompareAndSwapInt64(ptr, old, value) {
+			return
+		}
+	}
+}
+
+func writeJSONL(path string, in <-chan history.Record) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	buffer := bufio.NewWriterSize(file, 1<<20)
+	defer buffer.Flush()
+
+	enc := json.NewEncoder(buffer)
+	for r := range in {
+		if err := enc.Encode(r); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func splitNonEmpty(s string) []string {
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+func exitf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format+"\n", args...)
+	os.Exit(1)
+}

--- a/test/jepsen/history/history.go
+++ b/test/jepsen/history/history.go
@@ -1,0 +1,92 @@
+// Copyright 2022 ByteDance and/or its affiliates
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package history
+
+import (
+	"bufio"
+	"encoding/json"
+	"os"
+	"sort"
+)
+
+// Operation is the operation type in history records.
+type Operation string
+
+const (
+	OpCreate  Operation = "create"
+	OpUpdate  Operation = "update"
+	OpDelete  Operation = "delete"
+	OpGet     Operation = "get"
+	OpCompact Operation = "compact"
+)
+
+// Record is one completed operation in Jepsen-style history.
+type Record struct {
+	ID                  int64     `json:"id"`
+	ClientID            int       `json:"client_id"`
+	Operation           Operation `json:"operation"`
+	Key                 string    `json:"key,omitempty"`
+	RequestValue        string    `json:"request_value,omitempty"`
+	ExpectedModRevision int64     `json:"expected_mod_revision,omitempty"`
+	CompactRevision     int64     `json:"compact_revision,omitempty"`
+	InvokeUnixNano      int64     `json:"invoke_unix_nano"`
+	FinishUnixNano      int64     `json:"finish_unix_nano"`
+	Succeeded           bool      `json:"succeeded"`
+	ResponseRevision    int64     `json:"response_revision,omitempty"`
+	ResponseModRevision int64     `json:"response_mod_revision,omitempty"`
+	KeyFound            bool      `json:"key_found"`
+	ResponseValue       string    `json:"response_value,omitempty"`
+	TransportError      string    `json:"transport_error,omitempty"`
+	Note                string    `json:"note,omitempty"`
+}
+
+// LoadJSONL loads history records from a JSONL file.
+func LoadJSONL(path string) ([]Record, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	// Allow up to 10MB per line for large event payloads.
+	scanner.Buffer(make([]byte, 1024), 10*1024*1024)
+
+	records := make([]Record, 0, 1024)
+	for scanner.Scan() {
+		var r Record
+		if err := json.Unmarshal(scanner.Bytes(), &r); err != nil {
+			return nil, err
+		}
+		records = append(records, r)
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return records, nil
+}
+
+// SortByFinish sorts records by finish time, then invocation time, then ID.
+func SortByFinish(records []Record) {
+	sort.Slice(records, func(i, j int) bool {
+		if records[i].FinishUnixNano != records[j].FinishUnixNano {
+			return records[i].FinishUnixNano < records[j].FinishUnixNano
+		}
+		if records[i].InvokeUnixNano != records[j].InvokeUnixNano {
+			return records[i].InvokeUnixNano < records[j].InvokeUnixNano
+		}
+		return records[i].ID < records[j].ID
+	})
+}

--- a/test/jepsen/run.sh
+++ b/test/jepsen/run.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${ROOT_DIR}"
+
+ENDPOINTS="${ENDPOINTS:-127.0.0.1:2379}"
+DURATION="${DURATION:-2m}"
+WORKERS="${WORKERS:-16}"
+KEYS="${KEYS:-64}"
+KEY_PREFIX="${KEY_PREFIX:-/jepsen/kubebrain/}"
+TIMEOUT="${TIMEOUT:-3s}"
+SEED="${SEED:-0}"
+OPS_PER_WORKER="${OPS_PER_WORKER:-0}"
+COMPACT_INTERVAL="${COMPACT_INTERVAL:-30s}"
+COMPACT_REVISION_LAG="${COMPACT_REVISION_LAG:-100}"
+
+OUT_DIR="${OUT_DIR:-test/jepsen/artifacts}"
+HISTORY_FILE="${HISTORY_FILE:-${OUT_DIR}/history.jsonl}"
+REPORT_FILE="${REPORT_FILE:-${OUT_DIR}/report.json}"
+
+FAULT_CMD="${FAULT_CMD:-}"
+FAULT_INTERVAL_SEC="${FAULT_INTERVAL_SEC:-45}"
+
+mkdir -p "${OUT_DIR}"
+
+fault_pid=""
+cleanup() {
+  if [[ -n "${fault_pid}" ]] && kill -0 "${fault_pid}" 2>/dev/null; then
+    kill "${fault_pid}" || true
+    wait "${fault_pid}" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+if [[ -n "${FAULT_CMD}" ]]; then
+  (
+    while true; do
+      sleep "${FAULT_INTERVAL_SEC}"
+      echo "[fault] $(date -u +%FT%TZ) running: ${FAULT_CMD}"
+      bash -lc "${FAULT_CMD}" || true
+    done
+  ) &
+  fault_pid="$!"
+fi
+
+go run ./test/jepsen/harness \
+  -endpoints "${ENDPOINTS}" \
+  -duration "${DURATION}" \
+  -workers "${WORKERS}" \
+  -keys "${KEYS}" \
+  -key-prefix "${KEY_PREFIX}" \
+  -timeout "${TIMEOUT}" \
+  -seed "${SEED}" \
+  -ops-per-worker "${OPS_PER_WORKER}" \
+  -compact-interval "${COMPACT_INTERVAL}" \
+  -compact-revision-lag "${COMPACT_REVISION_LAG}" \
+  -out "${HISTORY_FILE}"
+
+go run ./test/jepsen/checker \
+  -history "${HISTORY_FILE}" \
+  -report "${REPORT_FILE}"
+
+echo "Jepsen run completed"
+echo "  history: ${HISTORY_FILE}"
+echo "  report : ${REPORT_FILE}"
+


### PR DESCRIPTION
## Summary
- add initial Jepsen-style workload harness under `test/jepsen/harness`
- add machine-checkable invariant checker under `test/jepsen/checker`
- add shared history model/loader (`JSONL`) under `test/jepsen/history`
- add end-to-end runner script with optional periodic fault command hook (`test/jepsen/run.sh`)
- add runbook documentation and artifacts directory conventions
- add `make jepsen` target

## Invariants checked
- global response revision monotonicity
- per-key write revision strictly increasing
- no phantom resurrection after delete (overlap-aware)

## Validation
- `go test ./test/jepsen/...`

Closes #6
